### PR TITLE
Add xlrd to requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,5 @@ pytest
 pytest-runner
 pyscal>0.1.4
 sphinx
+xlrd
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ numpy
 ecl2df>=0.5.0
 configsuite
 six>=1.12.0
+xlrd
 xtgeo


### PR DESCRIPTION
This is a temp fix as pyscal requires xlrd, but has forgot to
declare it up until 0.4.1