### PR TITLE
Pin configsuite to earlier than 0.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pyscal>=0.1.5
 matplotlib
 numpy
 ecl2df>=0.5.0
-configsuite
+configsuite<0.6.0
 six>=1.12.0
 xlrd
 xtgeo


### PR DESCRIPTION
sunsch and interp_relperm needs changes to be compatible with configsuite 0.6.0