### PR TITLE
Test x-bit on plugin scripts

### DIFF
--- a/tests/test_hook_implementations.py
+++ b/tests/test_hook_implementations.py
@@ -21,6 +21,17 @@ def test_hook_implementations():
         assert installable_jobs[wf_name].endswith(wf_location)
         assert os.path.isfile(installable_jobs[wf_name])
 
+    # Check executable bit is set on the EXECUTABLE path in
+    # each job file (assuming it is always on the first line)
+    src_path = os.path.join(os.path.dirname(__file__), "../src")
+    for _, job_config in expected_jobs.items():
+        executable_path = (
+            open(os.path.join(src_path, job_config)).readlines()[0].split()[1]
+        )
+        assert os.access(
+            os.path.join(src_path, "subscript/config_jobs", executable_path), os.X_OK
+        )
+
     assert set(installable_jobs.keys()) == set(expected_jobs.keys())
 
     expected_workflow_jobs = {}


### PR DESCRIPTION
Solve #123 

There might be prettier ways of determining the path of the file that should be executable, maybe it is available though the plugin manager api?