### PR TITLE
Add documentation setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ src/subscript/version.py
 .dir-locals.el
 '.'/
 *.swp
+
+# Auto documentation
+docs/subscript

--- a/README.md
+++ b/README.md
@@ -57,3 +57,17 @@ This section is dedicated to code contributors to subscript.
   * `pip install pylint`
   * Then run `pylint src`
   * Deviations from default (strict) pylint are stored in .pylintrc at root level, or as comments in the file e.g. `# pylint: disable=broad-except`
+
+## Documentation ##
+
+Install the development requirements
+```
+pip install -r requirements-dev.txt
+```
+
+Then, to build the documentation for subscript run the following command:
+```
+sphinx-build -b html -nv docs/ build/docs
+```
+
+And now you can find the start page of the documentation in the build folder: `build/docs/index.html`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,13 +15,12 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../"))
-
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
 
 # -- Project information -----------------------------------------------------
 
 project = "subscript"
-copyright = "2018, Equinor"
+copyright = "2020, Equinor"
 author = "Equinor"
 
 import subscript
@@ -50,9 +49,14 @@ release = version
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    'sphinx.ext.inheritance_diagram',
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
+    'sphinxarg.ext',
+    'autoapi.sphinx',
 ]
+
+autoapi_modules = {'subscript': None}
 
 autodoc_default_options = {"members": None}
 
@@ -90,8 +94,9 @@ pygments_style = None
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
-# html_theme = 'alabaster'
+
+html_theme = "sphinx_rtd_theme"
+
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,27 @@
 Welcome to subscript's documentation!
 =====================================
 
+This is the documentation for the subscript package
+
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+   :hidden:
 
-   subscript
+   self
 
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :hidden:
+   :caption: Scripts
+
+   scripts/index
+
+.. toctree::
+   :hidden:
+   :maxdepth: 10
+   :caption: Python modules
+
+   subscript/subscript
 
 Indices and tables
 ==================

--- a/docs/scripts/eclcompress.rst
+++ b/docs/scripts/eclcompress.rst
@@ -1,0 +1,12 @@
+ECLCOMPRESS
+===========
+
+ECLCOMPRESS is a script in the subscript package for compressing Eclipse input files.
+
+Command line
+------------
+
+.. argparse::
+   :module: subscript.eclcompress.eclcompress
+   :func: get_parser
+   :prog: eclcompress

--- a/docs/scripts/index.rst
+++ b/docs/scripts/index.rst
@@ -1,0 +1,5 @@
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   eclcompress

--- a/docs/subscript.rst
+++ b/docs/subscript.rst
@@ -1,4 +1,0 @@
-subscript
-=========
-
-.. automodule:: subscript

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,5 +8,8 @@ pytest
 pytest-runner
 pyscal>0.1.4
 sphinx
+sphinx-argparse
+sphinx_rtd_theme
+autoapi
 xlrd
 flake8

--- a/src/subscript/eclcompress/eclcompress.py
+++ b/src/subscript/eclcompress/eclcompress.py
@@ -249,7 +249,7 @@ def find_keyword_sets(filelines):
 
     Example:
 
-    If the deck consists of six lines like this:
+    If the deck consists of six lines like this::
 
         -- now comes porosity
         PORO
@@ -261,7 +261,8 @@ def find_keyword_sets(filelines):
     this will return [(1,4)] since 1 refers to the line with PORO and 4 refers
     to the line with the trailing slash.
 
-    More tricky keywords like (multiple records)
+    More tricky keywords like (multiple records)::
+
         EQUALS
           'FIPNUM' 0 1 0 1 0 1 10 /
           'FIPNUM' 1 2 1 2 1 2 20 /

--- a/src/subscript/summaryplot/summaryplot.py
+++ b/src/subscript/summaryplot/summaryplot.py
@@ -1,24 +1,21 @@
-"""
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
- Eclipse Summary plotter is based on ERT-Python
-  http://sib-docs.equinor.com/docs/ecl/index.html
-
- The source code is a part of the subscript repository:
-  https://github.com/equinor/subscript
-
-"""
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#     Eclipse Summary plotter is based on ERT-Python
+#      http://fmu-docs.equinor.com/docs/ecl/index.html
+#
+#     The source code is a part of the subscript repository:
+#      https://github.com/equinor/subscript
 
 from __future__ import division, absolute_import
 from __future__ import print_function, unicode_literals


### PR DESCRIPTION
Resolves https://github.com/equinor/fmu-dev/issues/3

This setup adds an initial setup for documentation using sphinx with the theme from [read the docs](https://sphinx-rtd-theme.readthedocs.io/en/stable/). It also includes the necessary setup for how automatic generation of documentation from argparse, and this is demonstrated for ECLCOMPRESS. In addition, it automatically generates documentation for all python modules. 

Enables https://github.com/equinor/subscript/issues/7, and documentation can easily be added for other scripts by following the ECLCOMPRESS example (and extending it with additional information).

When this PR is merge I will add the subscript documentation to fmu-docs.equinor.com :rocket: 