### PR TITLE
Support floating point days in sunsch

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,10 @@ autosummary_generate = True
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-# Avoid complaints (listing this should not be necessary!)
+# Avoid complaints, sphinx is run in nitpicky-mode (option "-n") to get
+# warnings for references it can't find, that means we need to add
+# ignore statements when we refer to objects outside subscript.
+# (this is typically the object type specs for each functions docstring)
 nitpick_ignore = [
     ("py:class", "str"),
     ("py:class", "int"),
@@ -77,6 +80,7 @@ nitpick_ignore = [
     ("py:class", "bool"),
     ("py:class", "datetime.date"),
     ("py:class", "pd.DataFrame"),
+    ("py:class", "opm.io.TimeVector"),
     ("py:class", "pyscal.WaterOilGas"),
     ("py:class", "argparse.ArgumentParser"),
     ("py:exc", "IOError"),

--- a/src/subscript/sunsch/sunsch.py
+++ b/src/subscript/sunsch/sunsch.py
@@ -218,7 +218,7 @@ CONFIG_SCHEMA_V2 = {
                                 "Days after refdate/startdate at which "
                                 "insertion should take place"
                             ),
-                            MK.Type: types.Integer,
+                            MK.Type: types.Number,
                             MK.AllowNone: True,
                         },
                         "string": {
@@ -275,7 +275,7 @@ def process_sch_config(conf):
             merges and inserts
 
     Returns:
-        string, containing the generated schedule section
+        opm.io.TimeVector:
     """
     # At least test code is calling this function with a dict as
     # config - convert it to a configsuite snapshot:

--- a/tests/test_sunsch.py
+++ b/tests/test_sunsch.py
@@ -177,6 +177,55 @@ def test_v1_to_v2():
     }
 
 
+def test_days_integer():
+    """Test that we can insert stuff a certain number of days
+    after startup"""
+    os.chdir(DATADIR)
+    sunschconf = {
+        "startdate": datetime.date(2020, 1, 1),
+        "enddate": datetime.date(2021, 1, 1),
+        "insert": [{"filename": "foo1.sch", "days": 10}],
+    }
+    sch = sunsch.process_sch_config(sunschconf)
+    assert datetime.datetime(2020, 1, 11, 0, 0, 0) in sch.dates
+
+    sunschconf = {
+        "startdate": datetime.date(2020, 1, 1),
+        "enddate": datetime.date(2021, 1, 1),
+        "insert": [{"filename": "foo1.sch", "days": 10.0}],
+    }
+    sch = sunsch.process_sch_config(sunschconf)
+    assert datetime.datetime(2020, 1, 11, 0, 0, 0) in sch.dates
+
+
+def test_days_float():
+    """Test that we can insert stuff a certain number of
+    floating point days after startup"""
+    os.chdir(DATADIR)
+    sunschconf = {
+        "startdate": datetime.date(2020, 1, 1),
+        "enddate": datetime.date(2021, 1, 1),
+        "insert": [{"filename": "foo1.sch", "days": 10.1}],
+    }
+    sch = sunsch.process_sch_config(sunschconf)
+    # The TimeVector object has the "correct" date including time,
+    # being 0.1 days after 2020-1-11
+    assert datetime.datetime(2020, 1, 11, 2, 24, 0) in sch.dates
+    # However, the clocktime is not included when the TimeVector
+    # object is stringified:
+    assert "11 'JAN' 2020/" in str(sch)
+
+    sunschconf = {
+        "startdate": datetime.date(2020, 1, 1),
+        "enddate": datetime.date(2021, 1, 1),
+        "insert": [{"filename": "foo1.sch", "days": 10.9}],
+    }
+    sch = sunsch.process_sch_config(sunschconf)
+    assert datetime.datetime(2020, 1, 11, 21, 36, 0) in sch.dates
+    # Rounding is downwards:
+    assert "11 'JAN' 2020/" in str(sch)
+
+
 def test_dateclip():
     """Test dateclipping"""
 


### PR DESCRIPTION
Sunsch sort of supports it already, but it is giving the user
an error message (that sunsch ignores).

Floating point days are rounded down.