### PR TITLE
Document jobs using plugin system

### DIFF
--- a/src/subscript/eclcompress/eclcompress.py
+++ b/src/subscript/eclcompress/eclcompress.py
@@ -47,6 +47,8 @@ Default list of files to compress is """ + " ".join(
     DEFAULT_FILES_TO_COMPRESS
 )
 
+CATEGORY = "utility.eclipse"
+
 # The string used here must match what is used as the DEFAULT
 # parameter in the ert joob config. It is not used elsewhere.
 MAGIC_DEFAULT_FILELIST = "__NONE__"

--- a/src/subscript/sunsch/sunsch.py
+++ b/src/subscript/sunsch/sunsch.py
@@ -26,6 +26,18 @@ logging.basicConfig()
 
 SUPPORTED_DATEGRIDS = ["monthly", "yearly", "weekly", "biweekly", "bimonthly"]
 
+DESCRIPTION = """Generate Eclipse Schedule file from merges and insertions.
+
+Reads a YAML-file specifying how a Eclipse Schedule section is to be
+produced given certain input files.
+
+Command line options override configuration in YAML.
+
+Output will not be generated unless the produced data is valid in
+Eclipse, checking provided by OPM."""
+
+CATEGORY = "utility.eclipse"
+
 
 @configsuite.validator_msg("Is dategrid a supported frequency")
 def _is_valid_dategrid(dategrid_str):
@@ -652,15 +664,7 @@ def get_parser():
     """Set up parser for command line utility"""
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="""Generate Eclipse Schedule file from merges and insertions.
-
-Reads a YAML-file specifying how a Eclipse Schedule section is to be
-produced given certain input files.
-
-Command line options override configuration in YAML.
-
-Output will not be generated unless the produced data is valid in
-Eclipse, checking provided by OPM.""",
+        description=DESCRIPTION,
         epilog="""YAML-file components::
 
  startdate - YYYY-MM-DD for the initial date of the simulation (START keyword)

--- a/tests/test_hook_implementations.py
+++ b/tests/test_hook_implementations.py
@@ -54,3 +54,18 @@ def test_executables():
         with open(os.path.join(src_path, job_config)) as f_handle:
             executable = f_handle.readlines()[0].split()[1]
             assert shutil.which(executable)
+
+
+@pytest.mark.skipif(sys.version_info.major < 3, reason="requires python3")
+def test_hook_implementations_job_docs():
+    pm = ErtPluginManager(plugins=[subscript.hook_implementations.jobs])
+
+    installable_jobs = pm.get_installable_jobs()
+
+    docs = pm.get_documentation_for_jobs()
+
+    assert set(docs.keys()) == set(installable_jobs.keys())
+
+    for job_name in installable_jobs.keys():
+        assert docs[job_name]["description"] != ""
+        assert docs[job_name]["category"] != "other"


### PR DESCRIPTION
Documentation can now be provided through the plugin system. The documentation will show up like the jobs here https://fmu-docs.equinor.com/docs/ert/reference/forward_models.html. So far I have just used the description from argparse, but this could be changed to a more specific documentation for the ERT job. Examples can also be provided if wanted/needed. (Other information than description, example and category that you can see on the link provided is automatically provided by the plugin system). When you provide a category, the main category (before the first dot) will be used to group the jobs into sections.