### PR TITLE
Wrapper so that run_external should work

### DIFF
--- a/src/subscript/runrms/runrms.py
+++ b/src/subscript/runrms/runrms.py
@@ -43,7 +43,16 @@ BETA = "RMS_test_latest"
 SITE = "/prog/roxar/site/"
 ROXAPISITE = "/project/res/roxapi"
 RHEL_ID = "/etc/redhat-release"
+
+# Note
+# From October/November 2020: If disable_komodo_exec is present, RMS will be launched
+# with komodo disabled. To make run_external (which enables komodo again for that
+# particular command) work when komodo is disabled, it is installed separately in a
+# PATH in RUN_EXTERNAL_PATH. A temp-file is used to start RMS with the augmented path,
+# modifying env directly from Python may not work.
+
 RUN_EXTERNAL_PATH = "export PATH=/project/res/roxapi/bin:$PATH"
+RUN_EXTERNAL_CMD = "/project/res/roxapi/bin/run_external"
 
 
 def touch(fname):
@@ -604,7 +613,12 @@ class RunRMS:
 
             # To make run_external work in a Komodo setting:
             # make a tmp file which also sets path; to be combined with run_external
+
             if shutil.which("disable_komodo_exec"):
+
+                if not shutil.which(RUN_EXTERNAL_CMD):
+                    raise RuntimeError(f"The script {RUN_EXTERNAL_CMD} is not present")
+
                 fhandle, fname = tempfile.mkstemp(text=True)
                 with open(fname, "w+") as fxx:
                     fxx.write(RUN_EXTERNAL_PATH + "\n")


### PR DESCRIPTION
RMS is now executed via disable_komodo_exec which
has a tmp file as input. The first line in the tmp file
will set PATH for the RMS session so that run_external is found