### PR TITLE
Update runrms to use new wrapper script if available

### DIFF
--- a/src/subscript/runrms/runrms.py
+++ b/src/subscript/runrms/runrms.py
@@ -43,15 +43,8 @@ SITE = "/prog/roxar/site/"
 ROXAPISITE = "/project/res/roxapi"
 RHEL_ID = "/etc/redhat-release"
 
-# Note
-# From October/November 2020: If disable_komodo_exec is present, RMS will be launched
-# with komodo disabled. To make run_external (which enables komodo again for that
-# particular command) work when komodo is disabled, it is installed separately in a
-# PATH in RUN_EXTERNAL_PATH. A temp-file is used to start RMS with the augmented path,
-# modifying env directly from Python may not work.
 
-RUN_EXTERNAL_PATH = "/project/res/roxapi/bin"
-RUN_EXTERNAL_CMD = "/project/res/roxapi/bin/run_external"
+RMS_ENV_PATH_PREFIX = "/project/res/roxapi/bin"
 
 
 def touch(fname):
@@ -585,6 +578,7 @@ class RunRMS:
             user = getpass.getuser()
             self.runloggerfile = "/tmp/runlogger_" + user + ".txt"
             touch(self.runloggerfile)
+            return 0
 
         else:
             print(_BColors.OKGREEN)
@@ -607,11 +601,12 @@ class RunRMS:
                 rms_exec_env["QT_SCALE_FACTOR"] = self.setdpiscaling
 
             if shutil.which("disable_komodo_exec"):
-                rms_exec_env["PATH_PREFIX"] = RUN_EXTERNAL_PATH
+                rms_exec_env["PATH_PREFIX"] = RMS_ENV_PATH_PREFIX
                 args_list = ["disable_komodo_exec"] + args_list
 
-            subprocess.run(args_list, env=rms_exec_env)
+            rms_process = subprocess.run(args_list, env=rms_exec_env)
             print(_BColors.ENDC)
+            return rms_process.returncode
 
     def showinfo(self):
         """Show info on RMS project"""
@@ -717,7 +712,7 @@ def main(args=None):
 
     if runner.project is None and runner.version_requested is None:
         runner.version_requested = "10.1.3"
-        runner.exe = "rms -v 10.1.3"
+        runner.exe = "rms"
 
     if runner.version_requested is None:
         runner.version_requested = runner.version_fromproject

--- a/tests/test_runrms.py
+++ b/tests/test_runrms.py
@@ -1,7 +1,9 @@
 """Test runrms script, but manual interactive testing is also needed"""
 import subprocess
-
+import os
+import stat
 import pytest
+import shutil
 
 from subscript.runrms import runrms as rr
 
@@ -56,3 +58,69 @@ def test_scan_rms(tmpdir):
     runner.scan_rms()
 
     assert runner.version_fromproject == "10.1.3"
+
+
+@pytest.mark.skipif(
+    not shutil.which("disable_komodo_exec"),
+    reason="The executable disable_komodo_exec is not available"
+)
+def test_runrms_disable_komodo_exec(tmpdir, monkeypatch):
+    with tmpdir.as_cwd():
+        with open("rms_fake", "w") as f:
+            f.write(
+                """\
+#!/usr/bin/env python3
+import os
+import sys
+
+errors = []
+
+BACKUPS_check=set([
+    "PATH",
+    "KOMODO_RELEASE",
+    "MANPATH",
+    "LD_LIBRARY_PATH",
+    "PYTHONPATH"
+])
+BACKUPS = set(os.environ["BACKUPS"].split(":"))
+
+if BACKUPS != BACKUPS_check:
+    errors.append(f"BACKUP error: {BACKUPS} not equal to {BACKUPS_check}")
+
+for backup in BACKUPS:
+    if f"{backup}_BACKUP" not in os.environ:
+        errors.append(f"The backup for {backup} is not set")
+
+PATH = os.environ["PATH"]
+PATH_PREFIX = os.environ["PATH_PREFIX"]
+if PATH.split(":")[0] != PATH_PREFIX:
+    errors.append(f"PATH_PREFIX ({PATH_PREFIX}), was not prepended to PATH ({PATH})")
+if PATH_PREFIX != "/project/res/roxapi/bin":
+    errors.append(f"The path for run_external is not corrent {PATH_PREFIX}")
+
+if "KOMODO_RELEASE" in os.environ:
+    errors.append(f"komodo release set: {os.environ['KOMODO_RELEASE']}")
+
+if errors:
+    for e in errors:
+        print(e)
+    sys.exit(1)
+sys.exit(0)
+"""
+            )
+
+        st = os.stat("rms_fake")
+        os.chmod("rms_fake", st.st_mode | stat.S_IEXEC)
+        monkeypatch.setenv("KOMODO_RELEASE", f"{os.getcwd()}/bleeding")
+        monkeypatch.setenv("_PRE_KOMODO_MANPATH", "some/man/path")
+        monkeypatch.setenv("_PRE_KOMODO_LD_LIBRARY_PATH", "some/ld/path")
+
+        runner = rr.RunRMS()
+        runner.do_parse_args(["-v", "10.1.3"])
+        runner.version_requested = "10.1.3"
+        runner.exe = "./rms_fake"
+        runner.pythonpath = ""
+        runner.pluginspath = "rms/plugins/path"
+
+        return_code = runner.launch_rms(empty=True)
+        assert return_code == 0


### PR DESCRIPTION
execute rms with subprocess

remove test checking for _PRE_RMS variables as they are not used by run_external anymore