### PR TITLE
Ensure regions in prtvol2csv are always strings

### DIFF
--- a/src/subscript/prtvol2csv/prtvol2csv.py
+++ b/src/subscript/prtvol2csv/prtvol2csv.py
@@ -282,6 +282,8 @@ def main():
             reg2fip = yaml.safe_load(yamlfile)
         if reg2fip and "region2fipnum" in reg2fip:
             reg2fipmap = reg2fip["region2fipnum"]
+            # Ensure all dictonary keys (region names) are strings:
+            reg2fipmap = {str(key): value for key, value in reg2fipmap.items()}
             # Invert the dictionary of lists, as we alse need to map
             # from fipnum to region:
             fip2regmap = {}

--- a/tests/test_prtvol2csv.py
+++ b/tests/test_prtvol2csv.py
@@ -94,6 +94,30 @@ def test_prtvol2csv_regions(tmpdir):
     assert len(dframe) == 3
 
 
+def test_prtvol2csv_regions_typemix(tmpdir):
+    """Test region support, getting data from yaml"""
+    prtfile = TESTDATADIR / "2_R001_REEK-0.PRT"
+
+    yamlexample = {
+        "region2fipnum": {
+            "RegionA": [1, 4, 6],
+            8: [2, 5],
+        }
+    }
+
+    tmpdir.chdir()
+    with open("regions.yml", "w") as reg_fh:
+        reg_fh.write(yaml.dump(yamlexample))
+    sys.argv = ["prtvol2csv", str(prtfile), "--regions", "regions.yml"]
+    prtvol2csv.main()
+    dframe = pd.read_csv("share/results/volumes/simulator_volume_region.csv")
+    assert not dframe.empty
+    assert "REGION" in dframe
+    assert "RegionA" in dframe["REGION"].values
+    assert "8" in dframe["REGION"].values
+    assert len(dframe) == 2
+
+
 def test_prtvol2csv_noresvol(tmpdir):
     """Test when FIPRESV is not included
 


### PR DESCRIPTION
Potentially solves #247, even though the added test did not trigger error in development system. The issue might relate to specific pandas vs yaml versions.