### PR TITLE
Add OPM as a direct dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ REQUIREMENTS = [
     "ert",
     "matplotlib",
     "numpy",
+    "opm",
     "pandas",
     "pyscal",
     "pyyaml",


### PR DESCRIPTION
At least `sunsch` uses OPM directly (other tools mostly through ecl2df)