### PR TITLE
Support daily dategrid in sunsch

### DIFF
--- a/docs/scripts/sunsch.rst
+++ b/docs/scripts/sunsch.rst
@@ -19,12 +19,14 @@ Features in short
 - Configuration in YAML format
 - Merging via DATE keyword
 - Optional clipping any events before or after chosen start and end dates
-- A "date grid" can be inserted. Weekly, biweekly, monthly, bimonthly and yearly
-  are supported. Monthly dates will be rounded to the first of every month.
+- A "date grid" can be inserted. Daily, weekly, biweekly, monthly, bimonthly
+  and yearly are supported. Monthly dates will be rounded to the first of
+  every month.
 - Insertion of small Schedule snippets, opening a well for example. Can
   be inserted either at dates relative a reference date, or at a specific date.
 - Schedule snippets can have parameters that get values when inserted.
-  This is similar to what one could achieve using DESIGN_KW, but with less temporary files.
+  This is similar to what one could achieve using DESIGN_KW, but with less
+  temporary files.
 
 When to use
 ------------

--- a/src/subscript/sunsch/sunsch.py
+++ b/src/subscript/sunsch/sunsch.py
@@ -25,7 +25,7 @@ from subscript import getLogger
 
 logger = getLogger(__name__)
 
-SUPPORTED_DATEGRIDS = ["monthly", "yearly", "weekly", "biweekly", "bimonthly"]
+SUPPORTED_DATEGRIDS = ["daily", "monthly", "yearly", "weekly", "biweekly", "bimonthly"]
 
 DESCRIPTION = """Generate Eclipse Schedule file from merges and insertions.
 

--- a/tests/test_sunsch.py
+++ b/tests/test_sunsch.py
@@ -565,6 +565,19 @@ def test_emptyfiles(tmpdir):
 
 def test_dategrid():
     """Test dategrid generation support in sunsch"""
+    # Daily
+    sch = sunsch.process_sch_config(
+        {
+            "startdate": datetime.date(2021, 1, 1),
+            "enddate": datetime.date(2022, 1, 1),
+            "dategrid": "daily",
+        }
+    )
+    assert len(sch) == 366
+    assert datetime.datetime(2021, 1, 1, 0, 0) in sch.dates
+    assert datetime.datetime(2021, 6, 6, 0, 0) in sch.dates
+    assert datetime.datetime(2022, 1, 1, 0, 0) in sch.dates
+
     # Yearly
     sch = sunsch.process_sch_config(
         {


### PR DESCRIPTION
Daily support has been there all the way, but apparently not tested, and forgotten when writing the user validation code.