### PR TITLE
Refactor prtvol2csv to use a new FipMapper class

### DIFF
--- a/src/subscript/prtvol2csv/fipmapper.py
+++ b/src/subscript/prtvol2csv/fipmapper.py
@@ -1,0 +1,245 @@
+"""The FipMapper class, mapping region/zones in RMS to FIPxxx in Eclipse.
+
+This API should be considered private to prtvol2csv until it has moved somewhere
+else"""
+import yaml
+from typing import Union
+from pathlib import Path
+
+from subscript import getLogger
+
+logger = getLogger(__name__)
+
+
+class FipMapper:
+    def __init__(
+        self,
+        yamlfile: Union[str, Path] = None,
+        mapdata: dict = None,
+        skipstring: Union[list, str] = None,
+    ):
+        """FipMapper is a utility class for being able to map between
+        regions/zones in the geomodel (RMS) and to different region divisions in the
+        dynamic model (Eclipse).
+
+        Primary usage is to determine which RMS regions corresponds to
+        which FIPNUMs, similarly for zones, and in both directions
+
+        Configuration is via a yaml-file or directly with a dictionary.
+
+        Several data structures in the dictionary can be used, such that
+        the needed information can be extracted from the global configurations
+        file.
+
+        Args:
+            yamlfile (Path): Filename
+            mapdata (dict): direct dictionary input. Provide only one of the
+                arguments, not both.
+            skipstring: List of strings which will be ignored (e.g. ["Totals"]).
+        """
+        self._mapdata = {}  # To be filled with data we need.
+
+        if skipstring is None:
+            self.skipstring = []
+        if isinstance(skipstring, str):
+            self.skipstring = [skipstring]
+
+        if yamlfile is not None and mapdata is not None:
+            raise ValueError(
+                "Initialize with either yamlfile or explicit data, not both"
+            )
+        if yamlfile is None and mapdata is None:
+            logger.warning("FipMapper initialized with no data")
+
+        if yamlfile is not None:
+            logger.info("Loading data from %s", yamlfile)
+            with open(yamlfile) as stream:
+                yamldata = yaml.safe_load(stream)
+            logger.debug(str(yamldata))
+        else:
+            yamldata = mapdata
+
+        if yamldata is not None:
+            self._get_explicit_mapdata(yamldata)
+
+        if yamldata is not None and "global" in yamldata:
+            # This is a fmu-config file.
+            self._fipdata_from_fmuconfigyaml(yamldata)
+
+        assert isinstance(self._mapdata, dict), "FipMapper needs a dictionary"
+
+        # Determine our capabilities:
+        self.has_fip2region = "fipnum2region" in self._mapdata
+        self.has_fip2zone = "fipnum2zone" in self._mapdata
+        self.has_region2fip = "region2fipnum" in self._mapdata
+        self.has_zone2fip = "zone2fipnum" in self._mapdata
+
+    def _get_explicit_mapdata(self, yamldata: dict):
+        """Fetch explicit mapping configuration from a dictionary,
+
+        Set internal flags when maps are found
+
+        Invert maps when possible/needed
+
+        Args:
+            yamldata (dict): Configuration object with predefined items
+                at the first level.
+        """
+        if self._mapdata is None:
+            self._mapdata = {}
+        if "fipnum2region" in yamldata:
+            self._mapdata["fipnum2region"] = yamldata["fipnum2region"]
+            if "region2fipnum" not in yamldata:
+                self._mapdata["region2fipnum"] = invert_map(
+                    self._mapdata["fipnum2region"], skipstring=self.skipstring
+                )
+            self.has_fip2region = True
+            self.has_region2fip = True
+
+        if "region2fipnum" in yamldata:
+            self._mapdata["region2fipnum"] = yamldata["region2fipnum"]
+            if "fipnum2region" not in yamldata:
+                logger.debug(self._mapdata["region2fipnum"])
+                self._mapdata["fipnum2region"] = invert_map(
+                    self._mapdata["region2fipnum"], skipstring=self.skipstring
+                )
+            self.has_fip2region = True
+            self.has_region2fip = True
+
+        if "fipnum2zone" in yamldata:
+            self._mapdata["fipnum2zone"] = yamldata["fipnum2zone"]
+            if "zone2fipnum" not in yamldata:
+                self._mapdata["zone2fipnum"] = invert_map(
+                    self._mapdata["fipnum2zone"], skipstring=self.skipstring
+                )
+            self.has_fip2zone = True
+            self.has_zone2fip = True
+
+        if "zone2fipnum" in yamldata:
+            self._mapdata["zone2fipnum"] = yamldata["zone2fipnum"]
+            if "fip2zone" not in yamldata:
+                self._mapdata["fipnum2zone"] = invert_map(
+                    self._mapdata["zone2fipnum"], skipstring=self.skipstring
+                )
+            self.has_fip2zone = True
+            self.has_zone2fip = True
+
+    def _fipdata_from_fmuconfigyaml(self, yamldict: dict):
+        """This function should be able to build mapping from region/zones to
+        FIPNUM based on data it finds in a fmu-config global_master_config.yml
+        file.
+
+        How that map should be deduced is not yet defined, and we only support
+        having the explicit maps "region2fipnum" etc under the global section
+
+        Args:
+            yamldict (dict):
+        """
+        self._get_explicit_mapdata(yamldict["global"])
+
+    def fip2region(self, fip: Union[list, int]) -> Union[list, str]:
+        """Maps FIP(NUM) integers to Region strings.
+
+        Args:
+            array (list): List/array of FIPNUMS, or integer.
+
+        Returns:
+            Union[list, str]: Returns str or list, depending on input. Region
+            names that are "integers" will be returned as strings.
+        """
+        if isinstance(fip, list):
+            return list(map(self.fip2region, fip))
+        print(self._mapdata)
+        assert "fipnum2region" in self._mapdata, "No data provided for fip2region"
+        try:
+            return self._mapdata["fipnum2region"][fip]
+        except KeyError:
+            logger.warning(
+                "Unknown fip %s, known map is %s",
+                str(fip),
+                str(self._mapdata["fipnum2region"]),
+            )
+            return None
+
+    def region2fip(self, region: Union[list, str]) -> Union[list, int]:
+        """Maps Region string(s) to FIPNUM(s)
+
+        Args:
+            array (list): List/array of FIPNUMS, or integer.
+
+        Returns:
+            int: FIPNUM value. None if the region is unknown
+        """
+        if isinstance(region, list):
+            return list(map(self.region2fip, region))
+        assert "region2fipnum" in self._mapdata, "No data provided for region2fip"
+        try:
+            return int(self._mapdata["region2fipnum"][region])
+        except KeyError:
+            logger.warning(
+                "Unknown region %s, known map is %s",
+                str(region),
+                str(self._mapdata["region2fipnum"]),
+            )
+            return None
+
+    def fip2zone(self, fip: Union[list, int]) -> Union[list, str]:
+        """Maps an array of FIPNUM integers to an array of Zone strings
+
+        Args:
+            array (list): List/array of FIPNUMS, or integer.
+
+        Returns:
+            list: Region strings. Always returned as list, and always as
+            strings, even if zone "names" are integers.
+        """
+        if isinstance(fip, list):
+            return list(map(self.fip2zone, fip))
+        assert "fipnum2zone" in self._mapdata, "No data provided for fip2zone"
+        try:
+            return self._mapdata["fipnum2zone"][fip]
+        except KeyError:
+            logger.warning("The zone belonging to FIPNUM %s is unknown", str(fip))
+            return None
+
+
+def invert_map(
+    dictmap: dict, join_on: str = ",", skipstring: Union[list, str] = None
+) -> dict:
+    """Invert a dictionary.
+
+    When input is many-to-one, the keys will be joined with the supplied join
+    string. Returned values inside dictionary will always be strings if joined,
+    if not joined, the value type is unchanged.
+
+    When the input is one-to-many,
+
+    Args:
+        dictmap (dict)
+        join_on (str)
+        skipstring: List of strings which will be ignored (e.g. "Totals").
+
+    Returns:
+        dict: Inverted map
+    """
+    if skipstring is None:
+        skipstring = []
+    if isinstance(skipstring, str):
+        skipstring = [skipstring]
+
+    inv_map = {}
+    for key, value in dictmap.items():
+        if key in skipstring or value in skipstring:
+            continue
+        if isinstance(value, list):
+            for _value in value:
+                inv_map[_value] = inv_map.get(_value, set()).union(set([key]))
+        else:
+            inv_map[value] = inv_map.get(value, set()).union(set([key]))
+    assert join_on is not None, "A join operation must be specified"
+    assert isinstance(join_on, str), f"The join_on must be a string, got {join_on}"
+    for key, value in inv_map.items():
+        inv_map[key] = list(inv_map[key])
+        inv_map[key].sort()
+        inv_map[key] = join_on.join(map(str, list(inv_map[key])))
+    return inv_map

--- a/src/subscript/prtvol2csv/fipmapper.py
+++ b/src/subscript/prtvol2csv/fipmapper.py
@@ -149,7 +149,6 @@ class FipMapper:
         """
         if isinstance(fip, list):
             return list(map(self.fip2region, fip))
-        print(self._mapdata)
         assert "fipnum2region" in self._mapdata, "No data provided for fip2region"
         try:
             return self._mapdata["fipnum2region"][fip]

--- a/src/subscript/prtvol2csv/prtvol2csv.py
+++ b/src/subscript/prtvol2csv/prtvol2csv.py
@@ -314,8 +314,6 @@ def main():
     volumes.to_csv(Path(tablesdir) / args.outputfilename)
     logger.info("Written CSV file %s", str(Path(tablesdir) / args.outputfilename))
 
-    print(volumes)
-
     deprecated_region_export(volumes.copy(), tablesdir, args)
 
 
@@ -333,7 +331,6 @@ def deprecated_region_export(volumes, tablesdir, args):
     """
     if args.yaml:
         reg2fip = yaml.safe_load(Path(args.yaml).read_text())
-        print(reg2fip)
         if "region2fipnum" in reg2fip:
             warnings.warn(
                 "Output pr. region from prtvol2csv will be removed in a later version",
@@ -390,7 +387,6 @@ def prtvol2df(simvolumes_df, resvolumes_df, fipmapper=None):
 
     if fipmapper is not None:
         if fipmapper.has_fip2region:
-            print(volumes.index)
             volumes["REGION"] = list(map(fipmapper.fip2region, volumes.index))
         if fipmapper.has_fip2zone:
             volumes["ZONE"] = list(map(fipmapper.fip2zone, volumes.index))

--- a/tests/test_fipmapper.py
+++ b/tests/test_fipmapper.py
@@ -1,0 +1,54 @@
+import pytest
+
+from subscript.prtvol2csv import fipmapper
+
+
+@pytest.mark.parametrize(
+    "input_dict, expected_inverse",
+    [
+        ({}, {}),
+        ({"foo": "bar"}, {"bar": "foo"}),
+        ({"foo": "1", "bar": "2"}, {"1": "foo", "2": "bar"}),
+        ({"foo": "1", "bar": "1"}, {"1": "bar,foo"}),
+        ({"foo": 1, "bar": 1}, {1: "bar,foo"}),
+        ({1: "foo", 2: "foo"}, {"foo": "1,2"}),
+        ({2: "foo", 1: "foo"}, {"foo": "1,2"}),
+        ({"foo": [1, 2], "bar": [3, 4]}, {1: "foo", 2: "foo", 3: "bar", 4: "bar"}),
+        (
+            {"foo": [1, 2], "bar": [3, 4], "Totals": [1, 2, 3, 4]},
+            {1: "Totals,foo", 2: "Totals,foo", 3: "Totals,bar", 4: "Totals,bar"},
+        ),
+    ],
+)
+def test_invert_map(input_dict, expected_inverse):
+    assert fipmapper.invert_map(input_dict) == expected_inverse
+
+
+def test_invert_map_skipstring():
+    input_dict = {"foo": [1, 2], "bar": [3, 4], "Totals": [1, 2, 3, 4]}
+    assert fipmapper.invert_map(input_dict, skipstring="Totals") == {
+        1: "foo",
+        2: "foo",
+        3: "bar",
+        4: "bar",
+    }
+
+
+def test_fipmapper_empty():
+    mapper = fipmapper.FipMapper()
+    assert mapper.has_region2fip is False
+    assert mapper.has_zone2fip is False
+    assert mapper.has_fip2region is False
+    assert mapper.has_fip2zone is False
+
+
+def test_fipmapper():
+    mapper = fipmapper.FipMapper(
+        mapdata={"fipnum2region": {1: "West-Brent", 2: "East-Sognefjord"}}
+    )
+    assert mapper.fip2region(1) == "West-Brent"
+    assert mapper.fip2region(2) == "East-Sognefjord"
+    assert mapper.fip2region([1, 2]) == ["West-Brent", "East-Sognefjord"]
+    assert mapper.region2fip("West-Brent") == 1
+    assert mapper.region2fip(["West-Brent"]) == [1]
+    assert mapper.region2fip(["West-Brent", "East-Sognefjord"]) == [1, 2]

--- a/tests/test_prtvol2csv.py
+++ b/tests/test_prtvol2csv.py
@@ -9,6 +9,7 @@ import pandas as pd
 import yaml
 
 from subscript.prtvol2csv import prtvol2csv
+from subscript.prtvol2csv.fipmapper import FipMapper
 
 TESTDATADIR = Path(__file__).absolute().parent / "data/reek/eclipse/model"
 
@@ -19,7 +20,7 @@ def test_currently_in_place_from_prt(tmpdir):
     Path("FOO.PRT").write_text(
         """
 
-                                                           ===================================
+                                                          ===================================
                                                           :  RESERVOIR VOLUMES      RM3     :
       :---------:---------------:---------------:---------------:---------------:---------------:
       : REGION  :  TOTAL PORE   :  PORE VOLUME  :  PORE VOLUME  : PORE VOLUME   :  PORE VOLUME  :
@@ -54,12 +55,88 @@ def test_prtvol2csv(tmpdir):
     sys.argv = ["prtvol2csv", "--debug", str(prtfile)]
     prtvol2csv.main()
     dframe = pd.read_csv("share/results/volumes/simulator_volume_fipnum.csv")
-    assert "FIPNUM" in dframe
-    assert "STOIIP_OIL" in dframe
-    assert "HCPV_TOTAL" in dframe  # This comes from the resvol extraction
-    assert "PORV_TOTAL" in dframe  # also
-    assert not dframe.empty
-    assert len(dframe) == 6
+
+    expected = pd.DataFrame.from_dict(
+        {
+            "FIPNUM": {0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 5: 6},
+            "STOIIP_OIL": {
+                0: 10656981.0,
+                1: 0.0,
+                2: 10720095.0,
+                3: 0.0,
+                4: 6976894.0,
+                5: 0.0,
+            },
+            "ASSOCIATEDOIL_GAS": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0.0},
+            "STOIIP_TOTAL": {
+                0: 10656981.0,
+                1: 0.0,
+                2: 10720095.0,
+                3: 0.0,
+                4: 6976894.0,
+                5: 0.0,
+            },
+            "WATER_TOTAL": {
+                0: 59957809.0,
+                1: 77110073.0,
+                2: 56914143.0,
+                3: 72699051.0,
+                4: 37834559.0,
+                5: 38919965.0,
+            },
+            "GIIP_GAS": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0.0},
+            "ASSOCIATEDGAS_OIL": {
+                0: 1960884420.0,
+                1: 0.0,
+                2: 1972497390.0,
+                3: 0.0,
+                4: 1283748490.0,
+                5: 0.0,
+            },
+            "GIIP_TOTAL": {
+                0: 1960884420.0,
+                1: 0.0,
+                2: 1972497390.0,
+                3: 0.0,
+                4: 1283748490.0,
+                5: 0.0,
+            },
+            "PORV_TOTAL": {
+                0: 78802733.0,
+                1: 79481140.0,
+                2: 75757104.0,
+                3: 74929403.0,
+                4: 50120783.0,
+                5: 40111683.0,
+            },
+            "HCPV_OIL": {
+                0: 17000359.0,
+                1: 0.0,
+                2: 17096867.0,
+                3: 0.0,
+                4: 11127443.0,
+                5: 0.0,
+            },
+            "WATER_PORV": {
+                0: 61802374.0,
+                1: 79481140.0,
+                2: 58660238.0,
+                3: 74929403.0,
+                4: 38993340.0,
+                5: 40111683.0,
+            },
+            "HCPV_GAS": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0.0},
+            "HCPV_TOTAL": {
+                0: 17000359.0,
+                1: 0.0,
+                2: 17096867.0,
+                3: 0.0,
+                4: 11127443.0,
+                5: 0.0,
+            },
+        }
+    )
+    pd.testing.assert_frame_equal(dframe, expected)
 
 
 def test_find_prtfile(tmpdir):
@@ -80,14 +157,86 @@ def test_find_prtfile(tmpdir):
     assert prtvol2csv.find_prtfile("FOO.PRT") == "FOO.PRT"
 
 
+def test_prtvol2df(tmpdir):
+    simv = pd.DataFrame([{"STOIIP_OIL": 1000}], index=[1])
+    resv = pd.DataFrame([{"PORV_TOTAL": 1000}], index=[1])
+
+    # This function is simple concatenation horizontally:
+    volumes = prtvol2csv.prtvol2df(simv, resv)
+    pd.testing.assert_frame_equal(
+        volumes, pd.DataFrame([{"STOIIP_OIL": 1000, "PORV_TOTAL": 1000}], index=[1])
+    )
+    # Index is [1] implicitly, and refers to FIPNUM.
+    assert "REGION" not in prtvol2csv.prtvol2df(simv, resv, FipMapper())
+    assert "ZONE" not in prtvol2csv.prtvol2df(simv, resv, FipMapper())
+
+    # Add a non-trivial FipMapper:
+    print(
+        prtvol2csv.prtvol2df(
+            simv, resv, FipMapper(mapdata={"region2fipnum": {"West": 1}})
+        )
+    )
+
+    assert prtvol2csv.prtvol2df(
+        simv, resv, FipMapper(mapdata={"region2fipnum": {"West": 1}})
+    )["REGION"].values == ["West"]
+
+    # Reverse the supplied map, should give the same:
+    assert prtvol2csv.prtvol2df(
+        simv, resv, FipMapper(mapdata={"fipnum2region": {1: "West"}})
+    )["REGION"].values == ["West"]
+
+    # And then for zones:
+    assert prtvol2csv.prtvol2df(
+        simv, resv, FipMapper(mapdata={"fipnum2zone": {1: "Upper"}})
+    )["ZONE"].values == ["Upper"]
+    assert prtvol2csv.prtvol2df(
+        simv, resv, FipMapper(mapdata={"zone2fipnum": {"Upper": 1}})
+    )["ZONE"].values == ["Upper"]
+    # if we use {"Upper": "1"} it will fail, but no pytest.raises on
+    # that yet, perhaps it will be fixed later.
+
+    # Check integer handling through yaml:
+    tmpdir.chdir()
+    Path("z2f_int.yml").write_text(yaml.dump({"zone2fipnum": {"Upper": 1}}))
+    assert prtvol2csv.prtvol2df(simv, resv, FipMapper(yamlfile="z2f_int.yml"))[
+        "ZONE"
+    ].values == ["Upper"]
+
+    # Both zone and regions at the same time:
+    volumes = prtvol2csv.prtvol2df(
+        simv,
+        resv,
+        FipMapper(mapdata={"fipnum2region": {1: "West"}, "zone2fipnum": {"Upper": 1}}),
+    )
+    assert volumes["REGION"].values == ["West"]
+    assert volumes["ZONE"].values == ["Upper"]
+
+    # Simple global_master_config support:
+    Path("global_master_config.yml").write_text(
+        yaml.dump({"global": {"zone2fipnum": {"Upper": 1}}})
+    )
+    assert prtvol2csv.prtvol2df(
+        simv, resv, FipMapper(yamlfile="global_master_config.yml")
+    )["ZONE"].values == ["Upper"]
+
+
 @pytest.mark.integration
 def test_integration():
     """Test that the endpoint is installed"""
     assert subprocess.check_output(["prtvol2csv", "-h"])
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="Test function requires Python 3.7 or higher"
+)
+@pytest.mark.integration
 def test_prtvol2csv_regions(tmpdir):
-    """Test region support, getting data from yaml"""
+    """Test region support, getting data from yaml.
+
+    The functionality of writing CSV data grouped by regions will
+    be removed later from prtvol2csv.
+    """
     prtfile = TESTDATADIR / "2_R001_REEK-0.PRT"
 
     yamlexample = {
@@ -95,23 +244,48 @@ def test_prtvol2csv_regions(tmpdir):
             "RegionA": [1, 4, 6],
             "RegionB": [2, 5],
             "Totals": [1, 2, 3, 4, 5, 6],
-        }
+        },
+        "zone2fipnum": {"Upper": [1, 2], "Mid": [3, 4], "Lower": [5, 6]},
     }
 
+    expected_dframe = pd.DataFrame.from_dict(
+        {
+            "REGION": {0: "RegionA", 1: "RegionB", 2: "Totals"},
+            "STOIIP_OIL": {0: 10656981.0, 1: 6976894.0, 2: 28353970.0},
+            "ASSOCIATEDOIL_GAS": {0: 0.0, 1: 0.0, 2: 0.0},
+            "STOIIP_TOTAL": {0: 10656981.0, 1: 6976894.0, 2: 28353970.0},
+            "WATER_TOTAL": {0: 171576825.0, 1: 114944632.0, 2: 343435600.0},
+            "GIIP_GAS": {0: 0.0, 1: 0.0, 2: 0.0},
+            "ASSOCIATEDGAS_OIL": {0: 1960884420.0, 1: 1283748490.0, 2: 5217130300.0},
+            "GIIP_TOTAL": {0: 1960884420.0, 1: 1283748490.0, 2: 5217130300.0},
+            "PORV_TOTAL": {0: 193843819.0, 1: 129601923.0, 2: 399202846.0},
+            "HCPV_OIL": {0: 17000359.0, 1: 11127443.0, 2: 45224669.0},
+            "WATER_PORV": {0: 176843460.0, 1: 118474480.0, 2: 353978178.0},
+            "HCPV_GAS": {0: 0.0, 1: 0.0, 2: 0.0},
+            "HCPV_TOTAL": {0: 17000359.0, 1: 11127443.0, 2: 45224669.0},
+            "FIPNUM": {0: "1 4 6", 1: "2 5", 2: "1 2 3 4 5 6"},
+        }
+    )
     tmpdir.chdir()
     with open("regions.yml", "w") as reg_fh:
         reg_fh.write(yaml.dump(yamlexample))
-    sys.argv = ["prtvol2csv", str(prtfile), "--regions", "regions.yml"]
+    result = subprocess.run(
+        ["prtvol2csv", str(prtfile), "--regions", "regions.yml"],
+        check=True,
+        capture_output=True,
+    )
+    output = result.stdout.decode() + result.stderr.decode()
+    assert "FutureWarning" in output
     prtvol2csv.main()
     dframe = pd.read_csv("share/results/volumes/simulator_volume_region.csv")
-    assert not dframe.empty
-    assert "REGION" in dframe
-    assert "Totals" in dframe["REGION"].values
-    assert "RegionA" in dframe["REGION"].values
-    assert "RegionB" in dframe["REGION"].values
-    assert len(dframe) == 3
+    print("Computed:")
+    print(dframe)
+    print("Reference")
+    print(expected_dframe)
+    pd.testing.assert_frame_equal(dframe, expected_dframe)
 
 
+@pytest.mark.integration
 def test_prtvol2csv_regions_typemix(tmpdir):
     """Test region support, getting data from yaml"""
     prtfile = TESTDATADIR / "2_R001_REEK-0.PRT"
@@ -124,18 +298,19 @@ def test_prtvol2csv_regions_typemix(tmpdir):
     }
 
     tmpdir.chdir()
-    with open("regions.yml", "w") as reg_fh:
-        reg_fh.write(yaml.dump(yamlexample))
+    Path("regions.yml").write_text(yaml.dump(yamlexample))
     sys.argv = ["prtvol2csv", str(prtfile), "--regions", "regions.yml"]
     prtvol2csv.main()
     dframe = pd.read_csv("share/results/volumes/simulator_volume_region.csv")
     assert not dframe.empty
     assert "REGION" in dframe
+    assert "ZONE" not in dframe
     assert "RegionA" in dframe["REGION"].values
     assert "8" in dframe["REGION"].values
     assert len(dframe) == 2
 
 
+@pytest.mark.integration
 def test_prtvol2csv_noresvol(tmpdir):
     """Test when FIPRESV is not included
 


### PR DESCRIPTION
The FipMapper class is a first version of an API that may
later move out of subscript (fmu-config is a candidate).

Also deprecate the region export, and the implicit mkdir.
Both these feature should be taken out at some point