### PR TITLE
Bugfix prtvol2csv for non-existing fipnums

### DIFF
--- a/src/subscript/prtvol2csv/prtvol2csv.py
+++ b/src/subscript/prtvol2csv/prtvol2csv.py
@@ -367,7 +367,7 @@ def deprecated_region_export(volumes, tablesdir, args):
             volumesbyregions = {}
             for reg in reg2fipmap:
                 volumesbyregions[reg] = pd.DataFrame(
-                    volumes.loc[reg2fipmap[reg]].sum()
+                    volumes.loc[volumes.index.intersection(reg2fipmap[reg])].sum()
                 ).transpose()
                 # Space separated list of fipnums involved in this region
                 volumesbyregions[reg]["FIPNUM"] = " ".join(map(str, reg2fipmap[reg]))

--- a/tests/test_prtvol2csv.py
+++ b/tests/test_prtvol2csv.py
@@ -215,6 +215,20 @@ def test_prtvol2df(tmpdir):
     assert volumes["REGION"].values == ["West"]
     assert volumes["ZONE"].values == ["Upper"]
 
+    # fipnummaps referring to non-existing fipnums:
+    volumes = prtvol2csv.prtvol2df(
+        simv,
+        resv,
+        FipMapper(
+            mapdata={
+                "fipnum2region": {1: "West", 50: "Antarctica"},
+                "zone2fipnum": {"Upper": 1, "Mantel": 100},
+            }
+        ),
+    )
+    assert "Antarctica" not in volumes["REGION"]
+    assert "Mantel" not in volumes["ZONE"]
+
     # Simple global_master_config support:
     Path("global_master_config.yml").write_text(
         yaml.dump({"global": {"zone2fipnum": {"Upper": 1}}})


### PR DESCRIPTION
The deprecated region export crashes if yaml files
mention fipnums that are empty/missing