### PR TITLE
Fix tests on komodo deploy

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -1,4 +1,4 @@
-
-install_package () {
-    pip install .[tests,docs]
+install_test_dependencies () {
+  pip install -r test_requirements.txt
+  pip install -r docs_requirements.txt
 }

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,0 +1,5 @@
+
+sphinx
+sphinx-argparse
+sphinx_rtd_theme
+autoapi

--- a/setup.py
+++ b/setup.py
@@ -81,22 +81,12 @@ SETUP_REQUIREMENTS = [
     "check-manifest",
 ]
 
-TEST_REQUIREMENTS = [
-    "black>=20.8b0",
-    "check-manifest",
-    "flake8",
-    "pytest",
-    "pytest-cov",
-    "pytest-mock",
-    "rstcheck",
-]
-DOCS_REQUIREMENTS = [
-    "sphinx",
-    "sphinx-argparse",
-    "sphinx_rtd_theme",
-    "autoapi",
-]
-EXTRAS_REQUIRE = {"tests": TEST_REQUIREMENTS, "docs": DOCS_REQUIREMENTS}
+with open("test_requirements.txt") as f:
+    test_requirements = f.read().splitlines()
+with open("docs_requirements.txt") as f:
+    docs_requirements = f.read().splitlines()
+
+EXTRAS_REQUIRE = {"tests": test_requirements, "docs": docs_requirements}
 
 setuptools.setup(
     name="subscript",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,7 @@
+black>=20.8b0
+check-manifest
+flake8
+pytest
+pytest-cov
+pytest-mock
+rstcheck


### PR DESCRIPTION
In order to test installed packages in komodo, we need to install test requirements without installing the package. For that we need to split test requirements into requirement.txt files.