### PR TITLE
Enforce deprecation for sunsch v1 config files

### DIFF
--- a/src/subscript/sunsch/sunsch.py
+++ b/src/subscript/sunsch/sunsch.py
@@ -7,6 +7,7 @@ hence the name. Later, this library has been merged into opm-common
 """
 
 import os
+import sys
 import datetime
 import tempfile
 import argparse
@@ -849,10 +850,10 @@ def main():
             # Only Py2 gets here.
             valid = False
         if not valid:
-            logger.warning(
+            logger.error(
                 (
-                    "Your configuration is DEPRECATED, "
-                    "switch to new format.\n"
+                    "Your configuration syntax is UNSUPPORTED, "
+                    "switch to new format:\n"
                     "The keys 'init' and 'merge' are "
                     "now merged into a key called 'files'\n"
                     "and the insert statements all start "
@@ -866,6 +867,8 @@ def main():
                     _v1_content_to_v2(yaml_config)
                 ).strip(),  # lgtm [py/call-to-non-callable]
             )
+            logger.error("Exiting script, no schedule file written")
+            sys.exit(1)
 
     if args.verbose:
         logger.setLevel(logging.INFO)

--- a/tests/test_sunsch.py
+++ b/tests/test_sunsch.py
@@ -73,43 +73,9 @@ def test_main_configv1(tmpdir, caplog):
     shutil.copytree(DATADIR, "testdata_sunsch")
     tmpdir.join("testdata_sunsch").chdir()
 
-    outfile = "schedule.sch"  # also in config_v1.yml
-
-    if os.path.exists(outfile):
-        os.unlink(outfile)
     sys.argv = ["sunsch", "config_v1.yml"]
-    sunsch.main()
-    assert "DEPRECATED" in caplog.text
-    assert os.path.exists(outfile)
-
-    schlines = open(outfile).readlines()
-    assert len(schlines) > 70
-
-    # Check footemplate.sch was included:
-    assert any(["A-90" in x for x in schlines])
-
-    # Sample check for mergeme.sch:
-    assert any(["WRFTPLT" in x for x in schlines])
-
-    # Check for foo1.sch, A-1 should occur twice
-    assert sum(["A-1" in x for x in schlines]) == 2
-
-    # Check for substitutetest:
-    assert any(["400000" in x for x in schlines])
-
-    # Check for randomid:
-    assert any(["A-4" in x for x in schlines])
-
-    # Test that we can have statements in the init file
-    # before the first DATES that are kept:
-
-    sch_conf = yaml.safe_load(open("config_v1.yml"))
-    print(sch_conf)
-    sch_conf["init"] = "initwithdates.sch"
-    sunsch.process_sch_config(sch_conf)
-
-    # BAR-FOO is a magic string that occurs before any DATES in initwithdates.sch
-    assert "BAR-FOO" in "".join(open(outfile).readlines())
+    with pytest.raises(SystemExit):
+        sunsch.main()
 
 
 def test_config_schema(tmpdir):


### PR DESCRIPTION
With this PR, sunsch will fail hard when given a V1 config file, but it will still print out an auto-converted V2 config. 

V1 config file format has been deprecated since June 2020.

Suggest to wait some more months before pruning all v1 support code.
