### PR TITLE
Adapt logger to be reused in subscript_internal

### DIFF
--- a/src/subscript/__init__.py
+++ b/src/subscript/__init__.py
@@ -41,6 +41,11 @@ def getLogger(module_name="subscript"):
     if not module_name:
         return getLogger("subscript")
 
+    # This logger is also used by subscript-internal, but we
+    # don't want to expose that detail and repo difference in
+    # the log output:
+    module_name = module_name.replace("subscript_internal", "subscript")
+
     compressed_name = []
     for elem in module_name.split("."):
         if len(compressed_name) == 0 or elem != compressed_name[-1]:

--- a/tests/test_subscriptlogger.py
+++ b/tests/test_subscriptlogger.py
@@ -21,6 +21,16 @@ def test_subscriptlogger_name():
         == "subscript.eclcompress.somesubmodule"
     )
 
+    assert subscript.getLogger("subscript_internal").name == "subscript"
+    assert (
+        subscript.getLogger("subscript_internal.completor").name
+        == "subscript.completor"
+    )
+    assert (
+        subscript.getLogger("subscript_internal.completor.sub").name
+        == "subscript.completor.sub"
+    )
+
 
 def test_default_logger_levels(capsys):
     """Verify that the intended usage of this logger have expected results"""


### PR DESCRIPTION
Subscript_internal  should be able to use the subscript logger identical to how subscript scripts use it.