### PR TITLE
Expose the environment given to codecov

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -34,4 +34,5 @@ jobs:
 
     - name: Upload coverage to Codecov
       run: |
+        env
         bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This is in response to https://about.codecov.io/security-update/ and confirms that no secrets have been exposed to codecov's bash uploader script.