### PR TITLE
Avoid numpy 1.20 warning

### DIFF
--- a/src/subscript/casegen_upcars/model.py
+++ b/src/subscript/casegen_upcars/model.py
@@ -568,7 +568,7 @@ class Model:
         if isinstance(fracture_property, int):
             data_type = np.int16
         else:
-            data_type = np.float
+            data_type = float
         props = np.empty(
             (self._total_nx, self._total_ny, self._total_nz), dtype=data_type
         )
@@ -613,7 +613,7 @@ class Model:
         if isinstance(fracture_x_property, int):
             data_type = np.int16
         else:
-            data_type = np.float
+            data_type = float
         props = np.empty(
             (self._total_nx, self._total_ny, self._total_nz), dtype=data_type
         )


### PR DESCRIPTION
tests/test_casegen_upcars.py::test_demo_large_scale
  /home/berland/projects/subscript/src/subscript/casegen_upcars/model.py:571: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    data_type = np.float