### PR TITLE
Pin opm to 2020.10.2, ecl2df is not compatible with 2021.04

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ REQUIREMENTS = [
     "ert",
     "matplotlib",
     "numpy",
-    "opm",
+    "opm==2020.10.2",
     "pandas",
     "protobuf",
     "pyscal",


### PR DESCRIPTION
Revert when  https://github.com/equinor/ecl2df/issues/303 is solved.