### PR TITLE
[fmuobs] Set uniform loglevel for submodules

### DIFF
--- a/src/subscript/fmuobs/fmuobs.py
+++ b/src/subscript/fmuobs/fmuobs.py
@@ -308,13 +308,16 @@ def fmuobs(
 ):
     # pylint: disable=too-many-arguments
     """Alternative to main() with named arguments"""
-    if verbose:
+    if verbose or debug:
         if __MAGIC_STDOUT__ in (csv, yml, ertobs):
-            raise SystemExit("Don't use verbose mode when writing to stdout")
-        logger.setLevel(logging.INFO)
-
-    if debug:
-        logger.setLevel(logging.DEBUG)
+            raise SystemExit("Don't use verbose/debug when writing to stdout")
+        loglevel = logging.INFO
+        if debug:
+            loglevel = logging.DEBUG
+        logger.setLevel(loglevel)
+        getLogger("subscript.fmuobs.parsers").setLevel(loglevel)
+        getLogger("subscript.fmuobs.writers").setLevel(loglevel)
+        getLogger("subscript.fmuobs.util").setLevel(loglevel)
 
     (filetype, dframe) = autoparse_file(inputfile)
 

--- a/src/subscript/fmuobs/parsers.py
+++ b/src/subscript/fmuobs/parsers.py
@@ -400,7 +400,7 @@ def ertobs2df(input_str: str, cwd=".", starttime: str = None) -> pd.DataFrame:
             print(obs_unit_split)
             raise ValueError
         obs_unit = {"CLASS": obs_unit_split[0], "LABEL": obs_unit_split[1]}
-        logger.info("Parsing observation %s %s", obs_unit["CLASS"], obs_unit["LABEL"])
+        logger.debug("Parsing observation %s %s", obs_unit["CLASS"], obs_unit["LABEL"])
         if len(obs_unit_split) > 2:
             obs_args = " ".join(obs_unit_split[2:])
             logger.debug("Subunit data: %s", str(obs_args))


### PR DESCRIPTION
Not sure if this is the way to do it, but have not found a solution that automates this through interitance of the log level for already initialized loggers.