### PR TITLE
[interp_relperm] Support family 2 input and pyscal-xlsx input

### DIFF
--- a/src/subscript/interp_relperm/interp_relperm.py
+++ b/src/subscript/interp_relperm/interp_relperm.py
@@ -20,23 +20,20 @@ from configsuite import MetaKeys as MK  # lgtm [py/import-and-import-from]
 logger = subscript.getLogger(__name__)
 
 DESCRIPTION = """Interpolation script for relperm tables.
-Script reads base/high/low SWOF and SGOF tables from files and
-interpolates in between, using interpolation parameter(s) in range
-[-1,1], so that -1, 0, and 1 corresponds to low, base, and high tables
-respectively.
 
-The base tables must contain both SWOF and SGOF to ensure consistent
-endpoints. Files for base, low and high must be declared, however
-they may be identical. Consequently, if either base, low or high
-is missing in the scal recommendation, two of the inputs can be
-set to point to the same file and by adjusting the interpolation
-range accordingly interpolation between base and high, or low and
-high may be achieved.
+The script reads files with SWOF/SGOF tables (or family 2) with base/high/low
+curves in SWOF and SGOF tables from files and interpolates in between, using
+interpolation parameter(s) in the range [-1,1], so that -1, 0, and 1
+correspond to low, base, and high respectively.
 
-Krw, Krow, Pcow interpolated using parameter param_w
+The tables must contain both SWOF and SGOF (or SWFN and SGFN) to ensure
+consistent endpoints. Files for base, low and high must be declared, however
+they may be identical in the case only "low" and "high" is available, and
+together with an adjusted interpolation parameter range.
 
-Krg, Krog, Pcog interpolated using parameter param_g
-
+The interpolation parameter ``param_w`` in the YAML configuration will be used
+to interpolate KRW, KROW and PCOW. The parameter ``param_g`` is used for KRG,
+KROG and PCOG. These parameters can be set individually pr. SATNUM.
 """
 
 EPILOGUE = """

--- a/src/subscript/interp_relperm/interp_relperm.py
+++ b/src/subscript/interp_relperm/interp_relperm.py
@@ -163,6 +163,9 @@ def _is_valid_table_entries(schema: dict):
                 and isinstance(schema["base"], tuple)
                 and isinstance(schema["high"], tuple)
             )
+    if "pyscalfile" in schema:
+        # If pyscalfile is given, we don't need low/base/high
+        return True
     return False
 
 

--- a/tests/test_interp_relperm.py
+++ b/tests/test_interp_relperm.py
@@ -4,12 +4,12 @@ from pathlib import Path
 
 import yaml
 import configsuite
-
-# import pathlib
-import pytest
 import pandas as pd
 
+import pytest
+
 from pyscal import PyscalFactory
+from pyscal.utils.testing import sat_table_str_ok
 from ecl2df import satfunc
 
 from subscript.interp_relperm import interp_relperm
@@ -471,6 +471,7 @@ def test_wrong_family(tmpdir):
 
 
 def test_mock_two_satnums_via_xlsx(tmpdir):
+    """Test initializing interp_relperm from a pyscal xlsx file"""
     tmpdir.chdir()
     TWO_SATNUM_PYSCAL_MOCK.reset_index().to_excel("scal_input.xlsx")
     config = {
@@ -576,6 +577,44 @@ def test_mock_two_satnums_via_files(tmpdir):
     outfile_str = open("outfile.inc").read()
     assert "interpolation to -0.9" not in outfile_str
     assert "interpolation to 0.8" in outfile_str
+
+
+@pytest.mark.parametrize(
+    "int_param, expected_file",
+    [(-1, "pess.inc"), (0, "base.inc"), (1, "opt.inc"), (-0.5, None), (0.5, None)],
+)
+def test_mock_two_satnums_via_fam2_files(tmpdir, int_param, expected_file):
+    tmpdir.chdir()
+    PyscalFactory.create_pyscal_list(
+        TWO_SATNUM_PYSCAL_MOCK.loc["low"], h=0.1
+    ).dump_family_2("pess.inc")
+    PyscalFactory.create_pyscal_list(
+        TWO_SATNUM_PYSCAL_MOCK.loc["base"], h=0.1
+    ).dump_family_2("base.inc")
+    PyscalFactory.create_pyscal_list(
+        TWO_SATNUM_PYSCAL_MOCK.loc["high"], h=0.1
+    ).dump_family_2("opt.inc")
+    config = {
+        "base": ["base.inc"],
+        "low": ["pess.inc"],
+        "high": ["opt.inc"],
+        "result_file": "outfile.inc",
+        "interpolations": [{"param_w": int_param, "param_g": int_param}],
+        "family": 2,
+        "delta_s": 0.1,
+    }
+
+    interp_relperm.process_config(config)
+    outfile_str = Path("outfile.inc").read_text()
+    outfile_df = satfunc.df(outfile_str)
+    if expected_file is not None:
+        expected_df = satfunc.df(Path(expected_file).read_text())
+        pd.testing.assert_frame_equal(outfile_df, expected_df)
+    else:
+        # Use test function from pyscal to assert that the produced file is
+        # valid for Eclipse (not testing numerically that the interpolation
+        # is correct)
+        sat_table_str_ok(outfile_str)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Refactoring and enhancements for interp_relperm to support family 2 input and also pyscal xlsx input.