### PR TITLE
Skip resinsight dev version testing by default

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -2,3 +2,8 @@ install_test_dependencies () {
   pip install -r test_requirements.txt
   pip install -r docs_requirements.txt
 }
+
+copy_test_files () {
+    cp -r $CI_SOURCE_ROOT/tests $CI_TEST_ROOT/tests
+    cp $CI_SOURCE_ROOT/setup.cfg $CI_TEST_ROOT
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ addopts =
 markers =
     integration: marks a test as an integration test
     plot: marks a test as interactive, plots will flash to the screen
+    ri_dev: A test using a dev version of ResInsight, skipped by default
 
 [tool:pylint]
 # Module docstrings are not required, there are other means of documenting at

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,18 +18,22 @@ def pytest_addoption(parser):
         default=False,
         help="run tests that display plots to the screen",
     )
+    parser.addoption(
+        "--ri_dev",
+        action="store_true",
+        default=False,
+        help="run tests that display plots to the screen",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
-    """Allow adding @pytest.mark.plot to a test function to
-    skip it unless --plot is supplied on the pytest command line"""
-    if config.getoption("--plot"):
-        # Do not skip tests when --plot is supplied on pytest command line
-        return
-    skip_plot = pytest.mark.skip(reason="need --plot option to run")
+    """Add skip markers to marked test functions skip it unless
+    options are supplied on the pytest command line"""
     for item in items:
-        if "plot" in item.keywords:
-            item.add_marker(skip_plot)
+        if "plot" in item.keywords and not config.getoption("--plot"):
+            item.add_marker(pytest.mark.skip(reason="need --plot option to run"))
+        if "ri_dev" in item.keywords and not config.getoption("--ri_dev"):
+            item.add_marker(pytest.mark.skip(reason="need --ri_dev option to run"))
 
 
 @pytest.fixture

--- a/tests/test_ri_wellmod.py
+++ b/tests/test_ri_wellmod.py
@@ -260,7 +260,7 @@ def test_main_lgr_reek(tmpdir, mocker):
     assert Path(outfile).exists() and file_contains(outfile, "OP_1")
 
 
-# Test development version
+@pytest.mark.ri_dev  # Need --ri_dev option to pytest to run this.
 @pytest.mark.skipif(
     not Path(RI_DEV).exists(), reason="No dev-version of ResInsight available"
 )


### PR DESCRIPTION
Also let Komodo pick up setup.cfg for this to work in komodo testing