### PR TITLE
Make interp_relperm robust to future pyscal versions

### DIFF
--- a/src/subscript/interp_relperm/interp_relperm.py
+++ b/src/subscript/interp_relperm/interp_relperm.py
@@ -277,6 +277,11 @@ def make_wateroilgas(dframe: pd.DataFrame, delta_s: float) -> pyscal.WaterOilGas
         krogcolname="KROG",
         pccolname="PCOG",
     )
+
+    # If sgro > 0, it is a gas condensate object, which cannot be
+    # mixed with non-gas condensate (during interpolation). Avoid pitfalls
+    # in the estimated sgro by always setting it to zero:
+    wog.gasoil.sgro = 0.0
     return wog
 
 


### PR DESCRIPTION
Without this fix, subscript is only compatible with pyscal <= v0.7.7

Problem is only visible when run towards master branch of pyscal (that means locally or in komodo bleeding).