### PR TITLE
Install resinsight for code coverage analysis

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,18 +23,24 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Install OPM-flow (for testing)
+    - name: Install OPM-flow and ResInsight (for testing)
       run: |
         sudo apt-get install software-properties-common
         sudo apt-add-repository ppa:opm/ppa
         sudo apt-get update
         sudo apt-get install mpi-default-bin
         sudo apt-get install libopm-simulators-bin
+        sudo apt-get install resinsight
 
     - name: Install subscript and test dependencies
       run: |
         pip install pip -U
         pip install .[tests]
+
+    - name: Force correct RIPS version
+      run: |
+        ResInsight --console --help | grep "ResInsight v. 2021.06" && pip install rips==2021.6.0.1 || true
+        ResInsight --console --help | grep "ResInsight v. 2020.10" && pip install rips==2020.10.0.2 || true
 
     - name: Generate coverage report
       run: |


### PR DESCRIPTION
Code coverage analysis underestimated the actual testing since the two github action yaml files were not synchronized.