### PR TITLE
Support clocktimes in sunsch for OPM 2021.10

### DIFF
--- a/src/subscript/sunsch/sunsch.py
+++ b/src/subscript/sunsch/sunsch.py
@@ -239,6 +239,8 @@ def datetime_from_date(
     date: Union[str, datetime.datetime, datetime.date]
 ) -> datetime.datetime:
     """Set time to 00:00:00 in a date"""
+    if isinstance(date, datetime.date):
+        return date
     if isinstance(date, str):
         raise ValueError(f"Is the string {date} a date?")
     return datetime.datetime.combine(date, datetime.datetime.min.time())

--- a/tests/test_sunsch.py
+++ b/tests/test_sunsch.py
@@ -295,12 +295,8 @@ def test_days_float(readonly_datadir):
         "insert": [{"filename": "foo1.sch", "days": 10.1}],
     }
     sch = sunsch.process_sch_config(sunschconf)
-    # The TimeVector object has the "correct" date including time,
-    # being 0.1 days after 2020-1-11
     assert datetime.datetime(2020, 1, 11, 2, 24, 0) in sch.dates
-    # However, the clocktime is not included when the TimeVector
-    # object is stringified:
-    assert "11 'JAN' 2020/" in str(sch)
+    assert "11 'JAN' 2020 02:24:00 /" in str(sch)
 
     sunschconf = {
         "startdate": datetime.date(2020, 1, 1),
@@ -309,8 +305,8 @@ def test_days_float(readonly_datadir):
     }
     sch = sunsch.process_sch_config(sunschconf)
     assert datetime.datetime(2020, 1, 11, 21, 36, 0) in sch.dates
-    # Rounding is downwards:
-    assert "11 'JAN' 2020/" in str(sch)
+
+    assert "11 'JAN' 2020 21:36:00 /" in str(sch)
 
 
 def test_starttime(readonly_datadir):
@@ -320,7 +316,7 @@ def test_starttime(readonly_datadir):
         "insert": [{"filename": "foo1.sch", "days": 10}],
     }
     sch = sunsch.process_sch_config(sunschconf)
-    assert "11 'FEB' 2020" in str(sch)
+    assert "11 'FEB' 2020 00:00:00" in str(sch)
 
     sunschconf = {
         "starttime": datetime.datetime(2020, 2, 1, 23, 59, 59),
@@ -328,8 +324,8 @@ def test_starttime(readonly_datadir):
         "insert": [{"filename": "foo1.sch", "days": 10}],
     }
     sch = sunsch.process_sch_config(sunschconf)
-    # Dates are rounded down, clock-times are not supported
-    assert "11 'FEB' 2020" in str(sch)
+
+    assert "11 'FEB' 2020 23:59:59" in str(sch)
 
 
 def test_dateclip(readonly_datadir):


### PR DESCRIPTION
Cherry-picked from https://github.com/equinor/subscript/pull/373

This PR will (at least) not work before a OPM 2021.10 is available and installed.