### PR TITLE
Updates for the recent 2021.10 ResInsight version

### DIFF
--- a/docs/scripts/ri_wellmod.rst
+++ b/docs/scripts/ri_wellmod.rst
@@ -76,9 +76,6 @@ perforated by the well A4 and a 1x1x3 refinement around A6::
 The corresponding CARFIN keywords are found in a separate file (here ``lgr_definitions.inc``), to
 be included in the GRID section of the Eclipse .DATA file.
 
-.. note:: The command-line LGR creation currently only works for init cases and in GUI mode, but
-     this will be fixed with the next release (March 2021).
-
 Syntax
 ------
 

--- a/src/subscript/ri_wellmod/ri_wellmod.py
+++ b/src/subscript/ri_wellmod/ri_wellmod.py
@@ -228,8 +228,10 @@ def launch_resinsight(console_mode: bool, command_line_parameters: List[str]):
 
     # Start with trying to find standard install, then search RI_HOME
     resinsight_exe = get_resinsight_exe()
+    if not resinsight_exe:
+        return None
 
-    riexe_path = Path(resinsight_exe)
+    riexe_path = Path(str(resinsight_exe))
     if (
         len(riexe_path.parts) >= 2
         and riexe_path.parts[0] == "/"

--- a/tests/test_ri_wellmod.py
+++ b/tests/test_ri_wellmod.py
@@ -30,28 +30,24 @@ def drogon_runpath():
     return None
 
 
-def has_display():
-    """
-    Check if an X display is available
-    """
-    return "DISPLAY" in os.environ and os.environ["DISPLAY"]
-
-
 def has_resinsight():
     """
     Check for a valid ResInsight install
     """
-    if ri_wellmod.get_resinsight_exe():
-        return True
+    resinsight_exe = ri_wellmod.get_resinsight_exe()
 
-    wrapper = ri_wellmod.find_and_wrap_resinsight_version(
-        ri_wellmod.get_rips_version_triplet()
-    )
-    if wrapper:
-        Path(wrapper).unlink()
-        return True
+    if not resinsight_exe:
+        return False
 
-    return False
+    riexe_path = Path(resinsight_exe)
+    if (
+        len(riexe_path.parts) >= 2
+        and riexe_path.parts[0] == "/"
+        and riexe_path.parts[1] == "tmp"
+    ):
+        riexe_path.unlink()
+
+    return True
 
 
 def file_contains(filename, string_to_find):
@@ -165,7 +161,6 @@ def test_drogon_lgr(tmp_path, mocker):
     not has_resinsight(), reason="Could not find a ResInsight executable"
 )
 @pytest.mark.skipif(drogon_runpath() is None, reason="Could not find Drogon data")
-@pytest.mark.skipif(not has_display(), reason="Requires X display")
 def test_main_lgr_cmdline(tmp_path, mocker):
     """Test creation of LGR"""
     os.chdir(tmp_path)
@@ -252,11 +247,9 @@ def test_main_initcase_reek(tmp_path, mocker):
     assert Path(outfile).exists() and file_contains(outfile, "OP_1")
 
 
-# This one requires a GUI (for now)
 @pytest.mark.skipif(
     not has_resinsight(), reason="Could not find a ResInsight executable"
 )
-@pytest.mark.skipif(not has_display(), reason="Requires X display")
 def test_main_lgr_reek(tmp_path, mocker):
     """Test creation of LGR on Reek"""
     os.chdir(tmp_path)


### PR DESCRIPTION
* Fixes on-prem rips/ResInsight version issue (detects and launches the correct version)
* Removes GUI dependency for LGR creation (docs updated accordingly)
