### PR TITLE
Update `eclmanual` and `runeclipse` for Eclipse `2021.3`.

### DIFF
--- a/src/subscript/legacy/eclmanual
+++ b/src/subscript/legacy/eclmanual
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-eclversion="2019.1"
-export ECLPATH="/prog/ecl/grid"
+eclversion="2021.3"
+export ECLPATH="/prog/res/ecl/grid"
 
 if [ "$1" == "-v" ] && [ "$2" != "" ] ; then
     eclversion=$2

--- a/src/subscript/legacy/runeclipse
+++ b/src/subscript/legacy/runeclipse
@@ -31,7 +31,7 @@ my $arch64 = "x86_64Linux";    # bsub resource string for 64bit
 # ---------------------------------------------------
 
 my $que_name  = "daily";
-my $version   = "2020.2";
+my $version   = "2021.3";
 my $memoryreq = 512;
 
 my $progname    = "eclipse";


### PR DESCRIPTION
- `runeclipse` will now default to Eclipse `2021.3`
- `eclmanual` didn't work for versions  `>2019.3` due to new installation folder. Path now leads to the new folder, and support for versions `<2018.2` is dropped by `eclmanual` 