### PR TITLE
Fixing typing issues in python 3.8

### DIFF
--- a/src/subscript/check_swatinit/check_swatinit.py
+++ b/src/subscript/check_swatinit/check_swatinit.py
@@ -1,7 +1,7 @@
 """SWATINIT qc tool"""
 import argparse
 import sys
-from typing import Dict, List, Any
+from typing import Any, Dict, List
 
 import ecl2df
 import numpy as np

--- a/src/subscript/check_swatinit/check_swatinit.py
+++ b/src/subscript/check_swatinit/check_swatinit.py
@@ -1,7 +1,7 @@
 """SWATINIT qc tool"""
 import argparse
 import sys
-from typing import Dict, List
+from typing import Dict, List, Any
 
 import ecl2df
 import numpy as np
@@ -478,7 +478,7 @@ def _evaluate_pc(
     satfunc: pd.DataFrame,
     sat_name: str = "SW",
     pc_name: str = "PCOW",
-) -> List[float]:
+) -> List[Any]:
     """Evaluate pc as a function of saturation on a scaled Pc-curve
 
     Args:

--- a/src/subscript/check_swatinit/pillarmodel.py
+++ b/src/subscript/check_swatinit/pillarmodel.py
@@ -227,10 +227,12 @@ class PillarModel:
         Returns:
             pc
         """
-        return np.interp(
-            s_water,
-            [self.swl[satnum - 1], 1],
-            [self.maxpc[satnum - 1] * scaling, self.minpc[satnum - 1] * scaling],
+        return float(
+            np.interp(
+                s_water,
+                [self.swl[satnum - 1], 1],
+                [self.maxpc[satnum - 1] * scaling, self.minpc[satnum - 1] * scaling],
+            )
         )
 
     def evaluate_sw(self, p_cap: float, scaling: float = 1.0, satnum: int = 1) -> float:
@@ -245,10 +247,12 @@ class PillarModel:
         Returns:
             sw: Between 0 and 1
         """
-        return np.interp(
-            p_cap,
-            [self.minpc[satnum - 1] * scaling, self.maxpc[satnum - 1] * scaling],
-            [self.swu[satnum - 1], self.swl[satnum - 1]],
+        return float(
+            np.interp(
+                p_cap,
+                [self.minpc[satnum - 1] * scaling, self.maxpc[satnum - 1] * scaling],
+                [self.swu[satnum - 1], self.swl[satnum - 1]],
+            )
         )
 
     def regions(self) -> str:

--- a/src/subscript/ri_wellmod/ri_wellmod.py
+++ b/src/subscript/ri_wellmod/ri_wellmod.py
@@ -231,6 +231,7 @@ def launch_resinsight(console_mode: bool, command_line_parameters: List[str]):
     if not resinsight_exe:
         return None
 
+    wrapper = False
     riexe_path = Path(str(resinsight_exe))
     if (
         len(riexe_path.parts) >= 2


### PR DESCRIPTION
Attempt to work around typing issues in python 3.8, allowing CI tests to complete. Hack-ish approach in lieu of numpy.typing for python 3.6 (requires numpy 1.20 which is not available for python < 3.7).