### PR TITLE
Runrms modify path

### DIFF
--- a/src/subscript/runrms/runrms.py
+++ b/src/subscript/runrms/runrms.py
@@ -54,7 +54,7 @@ RHEL_ID = pathlib.Path("/etc/redhat-release")
 
 
 # location of setup file; for testing this can be overriden by the --setup argument
-SETUP = "/project/res/roxapi/aux/runrms.yml"
+SETUP = "/prog/res/roxapi/aux/runrms.yml"
 
 
 def xwarn(mystring):

--- a/src/subscript/runrms/runrms.py
+++ b/src/subscript/runrms/runrms.py
@@ -224,7 +224,7 @@ class RunRMS:
         self.extstatus = "OK"
         self.beta = None
         self.rmsinstallsite = None
-        self.command = "rms"
+        self.command = "/prog/roxar/rms/rms"
         self.setdpiscaling = ""
         self.runloggerfile = "/prog/roxar/site/log/runrms_usage.log"
         self.userwarnings = []  # a list of user warnings to display e.g. upgrade ver.

--- a/src/subscript/runrms/runrms.py
+++ b/src/subscript/runrms/runrms.py
@@ -54,7 +54,7 @@ RHEL_ID = pathlib.Path("/etc/redhat-release")
 
 
 # location of setup file; for testing this can be overriden by the --setup argument
-SETUP = "/prog/res/roxapi/aux/runrms.yml"
+SETUP = "/prog/res/roxapi/config/runrms.yml"
 
 
 def xwarn(mystring):


### PR DESCRIPTION
Modify paths to enable a major change in Equinor how to run rms for end users

* The old `rms` script for user will in near future be modified so that users actually run `runrms`
* This change force `runrms` to point to `/prog/roxar/rms/rms` internally
* Also, the config file for runrms shall be `/prog/res/roxapi/config/runrms.yml`. Currently this is now symlinked to `/project/res/roxari/aux/runrms.yml` for a smooth transition