### PR TITLE
Pin `rstcheck` to `<6` due to API breakage

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,7 +6,7 @@ mypy
 pytest
 pytest-cov
 pytest-mock
-rstcheck
+rstcheck<6
 types-Jinja2
 types-PyYAML
 types-pkg_resources


### PR DESCRIPTION
`rstcheck` has removed the function `check` which is used in the test suite.