### PR TITLE
Move setting of simulators to pytest parameter

### DIFF
--- a/.github/workflows/subscript.yml
+++ b/.github/workflows/subscript.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests
+          pytest --flow-simulator="flow" tests
           # Check that repository is untainted by test code:
           git status --porcelain
           test -z "$(git status --porcelain)"

--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -7,3 +7,9 @@ copy_test_files () {
     cp -r $CI_SOURCE_ROOT/tests $CI_TEST_ROOT/tests
     cp $CI_SOURCE_ROOT/setup.cfg $CI_TEST_ROOT
 }
+
+start_tests () {
+    pushd $CI_TEST_ROOT/testpath
+    pytest --flow-simulator="/project/res/x86_64_RH_7/bin/flowrc15" --eclipse-simulator="runeclipse"
+    popd
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,20 @@ def pytest_addoption(parser):
         default=False,
         help="run tests that display plots to the screen",
     )
+    parser.addoption(
+        "--flow-simulator",
+        action="store",
+        default=None,
+        help="The path to flow simulator,"
+        " defaults to not running tests depending on flow",
+    )
+    parser.addoption(
+        "--eclipse-simulator",
+        action="store",
+        default=None,
+        help="The path to eclipse simulator,"
+        " defaults to not running tests depending on eclipse",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -43,3 +57,28 @@ def plot(request):
     """Provide a fixture that tests can use to evaluate whether
     --plot was present on the command line"""
     return request.config.getoption("--plot")
+
+
+@pytest.fixture
+def flow_simulator(request):
+    flow_path = request.config.getoption("--flow-simulator")
+    if flow_path is None:
+        pytest.skip("No flow executable given, see --flow-simulator")
+    return flow_path
+
+
+@pytest.fixture
+def eclipse_simulator(request):
+    eclipse_path = request.config.getoption("--eclipse-simulator")
+    if eclipse_path is None:
+        pytest.skip("No eclipse executable given, see --eclipse-simulator")
+    return eclipse_path
+
+
+@pytest.fixture(params=["eclipse", "flow"])
+def simulator(request):
+    simulator = request.param
+    simulator_path = request.config.getoption(f"--{simulator}-simulator")
+    if simulator_path is None:
+        pytest.skip(f"No {simulator} executable given, see --{simulator}-simulator")
+    return simulator_path


### PR DESCRIPTION
Use pytest command-line parameters to set the location of simulators
instead of looking for them in hardcoded paths.

Testing of 3.6 and 3.7 is failing, so they are removed as no longer supported versions.