### PR TITLE
Solve compatibility with Pyscal>0.9.2

### DIFF
--- a/src/subscript/check_swatinit/check_swatinit.py
+++ b/src/subscript/check_swatinit/check_swatinit.py
@@ -213,7 +213,8 @@ def human_report_pc_scaling(qc_frame: pd.DataFrame) -> str:
 
 
 def make_qc_gridframe(eclfiles: ecl2df.EclFiles) -> pd.DataFrame:
-    """Construct a dataframe with needed information for swatinit qc from an Eclipse run.
+    """Construct a dataframe with needed information for swatinit qc from an
+    Eclipse run.
 
     Makes a dataframe with one row for each active cell. Information from
     satfunc and equil merged in.

--- a/src/subscript/ri_wellmod/ri_wellmod.py
+++ b/src/subscript/ri_wellmod/ri_wellmod.py
@@ -401,15 +401,15 @@ def get_parser() -> argparse.ArgumentParser:
         "-w",
         nargs="+",
         default=None,
-        help="Optional comma-separated list of wells (wildcards allowed) to generate completions \
-            for (default=all wells in project)",
+        help="Optional comma-separated list of wells (wildcards allowed) to \
+            generate completions for (default=all wells in project)",
     )
     parser.add_argument(
         "--msw",
         nargs="+",
         default=None,
-        help="Optional comma-separated list of wells (wildcards allowed) to generate msw \
-            well definitions for (default=none)",
+        help="Optional comma-separated list of wells (wildcards allowed) to \
+            generate msw well definitions for (default=none)",
     )
     parser.add_argument(
         "--lgr",

--- a/tests/test_check_swatinit_simulators.py
+++ b/tests/test_check_swatinit_simulators.py
@@ -160,10 +160,11 @@ def test_swat_limited_by_ppcwmax_above_contact(simulator, tmp_path):
 
 
 def test_accepted_swatinit_slightly_above_contact(simulator, tmp_path):
-    """Test a "normal" scenario, SWATINIT is accepted and some PC scaling will be applied
-    some meters above the contact
+    """Test a "normal" scenario, SWATINIT is accepted and some PC scaling will
+    be applied some meters above the contact
 
-    QC-wise, these cells will not be flagged, but contribute to average PC_SCALING
+    QC-wise, these cells will not be flagged, but contribute to average
+    PC_SCALING
     """
     os.chdir(tmp_path)
     model = PillarModel(
@@ -202,8 +203,8 @@ def test_accepted_swatinit_slightly_above_contact(simulator, tmp_path):
 
 
 def test_accepted_swatinit_far_above_contact(simulator, tmp_path):
-    """Test a "normal" scenario, SWATINIT is accepted and some PC scaling will be applied
-    far above the contact
+    """Test a "normal" scenario, SWATINIT is accepted and some PC scaling will
+    be applied far above the contact
     """
     os.chdir(tmp_path)
     model = PillarModel(

--- a/tests/test_interp_relperm.py
+++ b/tests/test_interp_relperm.py
@@ -291,9 +291,20 @@ def mock_family_1():
         columns=columns,
         data=[[1, 3, 3, 3, 3, 0.1, 2, -2, 0.25, 300, 150]],
     )
-    PyscalFactory.create_pyscal_list(dframe_pess).dump_family_1("pess.inc")
-    PyscalFactory.create_pyscal_list(dframe_base).dump_family_1("base.inc")
-    PyscalFactory.create_pyscal_list(dframe_opt).dump_family_1("opt.inc")
+    Path("pess.inc").write_text(
+        PyscalFactory.create_pyscal_list(dframe_pess).build_eclipse_data(family=1),
+        encoding="utf-8",
+    )
+
+    Path("base.inc").write_text(
+        PyscalFactory.create_pyscal_list(dframe_base).build_eclipse_data(family=1),
+        encoding="utf-8",
+    )
+
+    Path("opt.inc").write_text(
+        PyscalFactory.create_pyscal_list(dframe_opt).build_eclipse_data(family=1),
+        encoding="utf-8",
+    )
 
 
 def test_mock(tmp_path):
@@ -397,14 +408,23 @@ def test_mock_two_satnums_via_files(tmp_path):
     """
     # pylint: disable=no-value-for-parameter
     os.chdir(tmp_path)
-    PyscalFactory.create_pyscal_list(TWO_SATNUM_PYSCAL_MOCK.loc["low"]).dump_family_1(
-        "pess.inc"
+    Path("pess.inc").write_text(
+        PyscalFactory.create_pyscal_list(
+            TWO_SATNUM_PYSCAL_MOCK.loc["low"]
+        ).build_eclipse_data(family=1),
+        encoding="utf-8",
     )
-    PyscalFactory.create_pyscal_list(TWO_SATNUM_PYSCAL_MOCK.loc["base"]).dump_family_1(
-        "base.inc"
+    Path("base.inc").write_text(
+        PyscalFactory.create_pyscal_list(
+            TWO_SATNUM_PYSCAL_MOCK.loc["base"]
+        ).build_eclipse_data(family=1),
+        encoding="utf-8",
     )
-    PyscalFactory.create_pyscal_list(TWO_SATNUM_PYSCAL_MOCK.loc["high"]).dump_family_1(
-        "opt.inc"
+    Path("opt.inc").write_text(
+        PyscalFactory.create_pyscal_list(
+            TWO_SATNUM_PYSCAL_MOCK.loc["high"]
+        ).build_eclipse_data(family=1),
+        encoding="utf-8",
     )
 
     config = {
@@ -489,15 +509,24 @@ def test_mock_two_satnums_via_files(tmp_path):
 def test_mock_two_satnums_via_fam2_files(tmp_path, int_param, expected_file):
     """Test that we can interpolate via family 2 input files"""
     os.chdir(tmp_path)
-    PyscalFactory.create_pyscal_list(
-        TWO_SATNUM_PYSCAL_MOCK.loc["low"], h=0.1
-    ).dump_family_2("pess.inc")
-    PyscalFactory.create_pyscal_list(
-        TWO_SATNUM_PYSCAL_MOCK.loc["base"], h=0.1
-    ).dump_family_2("base.inc")
-    PyscalFactory.create_pyscal_list(
-        TWO_SATNUM_PYSCAL_MOCK.loc["high"], h=0.1
-    ).dump_family_2("opt.inc")
+    Path("pess.inc").write_text(
+        PyscalFactory.create_pyscal_list(
+            TWO_SATNUM_PYSCAL_MOCK.loc["low"], h=0.1
+        ).build_eclipse_data(family=2),
+        encoding="utf-8",
+    )
+    Path("base.inc").write_text(
+        PyscalFactory.create_pyscal_list(
+            TWO_SATNUM_PYSCAL_MOCK.loc["base"], h=0.1
+        ).build_eclipse_data(family=2),
+        encoding="utf-8",
+    )
+    Path("opt.inc").write_text(
+        PyscalFactory.create_pyscal_list(
+            TWO_SATNUM_PYSCAL_MOCK.loc["high"], h=0.1
+        ).build_eclipse_data(family=2),
+        encoding="utf-8",
+    )
     config = {
         "base": ["base.inc"],
         "low": ["pess.inc"],


### PR DESCRIPTION
* Explicitly set socr to sorw, which pyscal >0.9.2 otherwise might interpret to be larger than sorw
  This is a scenario which we don't want to support in interp_relperm
* Fix deprecation warnings from pyscal on dump_family_*()
* Remove workarounds for ancient pyscal versions (<0.7.7)