### PR TITLE
Handle new IndexError message for empty decks in opm 2022.04

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ REQUIREMENTS = [
     "fmu-tools",
     "matplotlib",
     "numpy",
-    "opm==2021.10",
+    "opm>=2022.04",
     "packaging",
     "pandas",
     "protobuf",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ REQUIREMENTS = [
     "fmu-tools",
     "matplotlib",
     "numpy",
-    "opm>=2022.04",
+    "opm>=2021.10",
     "packaging",
     "pandas",
     "protobuf",

--- a/src/subscript/sunsch/sunsch.py
+++ b/src/subscript/sunsch/sunsch.py
@@ -416,8 +416,15 @@ def sch_file_nonempty(filename: str) -> bool:
         tmpschedule = TimeVector(datetime.date(1900, 1, 1))
         tmpschedule.load(filename)
     except IndexError as err:
+        if (
+            "vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)"
+            in str(err)
+        ):
+            # This is what we get from opm>=2022.04 for empty files.
+            return False
+
         if "Keyword index 0 is out of range" in str(err):
-            # This is what we get from opm for empty files.
+            # This is what we get from opm<2022.04 for empty files.
             return False
 
         # Try to workaround a non-explanatory error from opm-common:


### PR DESCRIPTION
Error message for requested deck keyword out of range apparently became less descriptive in `opm 2022.04`
Could alternatively keep the old message as well to support `2021.10`, but find it ok to force` 2022.04` to be able to catch it if `opm` switches back to the more descriptive message (have a feeling that it might not have been intended from `opm`'s)