### PR TITLE
Output dates in ISO-format from fmuobs

### DIFF
--- a/src/subscript/fmuobs/util.py
+++ b/src/subscript/fmuobs/util.py
@@ -10,6 +10,7 @@ CLASS_SHORTNAME = {
 
 
 ERT_DATE_FORMAT = "%d/%m/%Y"
+ERT_ISO_DATE_FORMAT = "%Y-%m-%d"
 ERT_ALT_DATE_FORMAT = "%d.%m.%Y"  # Not found in doc, but supported by ERT
 
 

--- a/src/subscript/fmuobs/writers.py
+++ b/src/subscript/fmuobs/writers.py
@@ -9,7 +9,11 @@ import numpy as np
 import pandas as pd
 
 from subscript import getLogger
-from subscript.fmuobs.util import CLASS_SHORTNAME, ERT_DATE_FORMAT, lowercase_dictkeys
+from subscript.fmuobs.util import (
+    CLASS_SHORTNAME,
+    ERT_ISO_DATE_FORMAT,
+    lowercase_dictkeys,
+)
 
 logger = getLogger(__name__)
 
@@ -36,10 +40,9 @@ def dfsummary2ertobs(obs_df: pd.DataFrame) -> str:
                 + "\n"
             )
         if "DATE" in row and not pd.isnull(row["DATE"]):
-            # Special formatting of the DATE
             ertobs_str += (
                 "    DATE = "
-                + str(pd.to_datetime(row["DATE"]).strftime(ERT_DATE_FORMAT))
+                + str(pd.to_datetime(row["DATE"]).strftime(ERT_ISO_DATE_FORMAT))
                 + ";\n"
             )
         for dataname in ["KEY", "DAYS", "RESTART", "VALUE", "ERROR", "SOURCE"]:
@@ -63,7 +66,7 @@ def dfblock2ertobs(obs_df: pd.DataFrame) -> str:
     block_obs_df = obs_df[obs_df["CLASS"] == "BLOCK_OBSERVATION"].copy()
     if "DATE" in block_obs_df:
         block_obs_df["DATE"] = pd.to_datetime(block_obs_df["DATE"]).dt.strftime(
-            ERT_DATE_FORMAT
+            ERT_ISO_DATE_FORMAT
         )
     for obslabel, block_df in block_obs_df.groupby("LABEL"):
         ertobs_str += "BLOCK_OBSERVATION " + obslabel + "\n{\n"
@@ -169,7 +172,7 @@ def dfgeneral2ertobs(obs_df: pd.DataFrame) -> str:
     gen_obs_df = obs_df[obs_df["CLASS"] == "GENERAL_OBSERVATION"]
     if "DATE" in gen_obs_df:
         gen_obs_df["DATE"] = pd.to_datetime(gen_obs_df["DATE"]).dt.strftime(
-            ERT_DATE_FORMAT
+            ERT_ISO_DATE_FORMAT
         )
     for _, row in gen_obs_df.iterrows():
         ertobs_str += "GENERAL_OBSERVATION " + str(row["LABEL"]) + " {\n"

--- a/tests/test_fmuobs_writers.py
+++ b/tests/test_fmuobs_writers.py
@@ -65,13 +65,13 @@ from subscript.fmuobs.writers import (
 {
     -- FOO BAR
     -- dontcrash
-    DATE = 01/06/2025;
+    DATE = 2025-06-01;
     VALUE = 2222.3;
     ERROR = 100.0;
 };
 SUMMARY_OBSERVATION WOPR:OP2
 {
-    DATE = 01/01/2026;
+    DATE = 2026-01-01;
     VALUE = 222.3;
     ERROR = 10.0;
 };
@@ -120,7 +120,7 @@ def test_dfsummary2ertobs(obs_df, expected_str):
             ),
             """BLOCK_OBSERVATION RFT_2006_OP1
 {
-    DATE = 05/04/1986;
+    DATE = 1986-04-05;
     OBS P1 {};
 };
 """,
@@ -142,7 +142,7 @@ def test_dfsummary2ertobs(obs_df, expected_str):
             """BLOCK_OBSERVATION RFT_2006_OP1
 {
     -- FOO
-    DATE = 05/04/1986;
+    DATE = 1986-04-05;
     -- bza
     OBS P1 {};
 };
@@ -174,7 +174,7 @@ def test_dfsummary2ertobs(obs_df, expected_str):
 {
     -- FOO
     -- dontcrash
-    DATE = 05/04/1986;
+    DATE = 1986-04-05;
     -- bza
     OBS P1 {};
     -- bzarrr
@@ -202,7 +202,7 @@ def test_dfsummary2ertobs(obs_df, expected_str):
             """BLOCK_OBSERVATION RFT_SWAT_2006_OP1
 {
     FIELD = SWAT;
-    DATE = 01/01/1900;
+    DATE = 1900-01-01;
     OBS P1 { I = 1; J = 2;};
 };
 """,
@@ -361,13 +361,13 @@ def test_dfgeneral2ertobs(obs_df, expected_str):
             """
 SUMMARY_OBSERVATION WOPR:OP1
 {
-    DATE = 01/01/2025;
+    DATE = 2025-01-01;
     VALUE = 2222.3;
     ERROR = 100.0;
 };
 BLOCK_OBSERVATION RFT_2006_OP1
 {
-    DATE = 05/04/1986;
+    DATE = 1986-04-05;
     OBS P1 {};
 };
 HISTORY_OBSERVATION WOPR:P1;


### PR DESCRIPTION
Non-ISO dates are now deprecated in ERT, so fmuobs should write to ISO-8601.