### PR TITLE
Casegen_UpCaRs: Add option to shift origin position to anywhere in the model

### DIFF
--- a/src/subscript/casegen_upcars/casegen_upcars.py
+++ b/src/subscript/casegen_upcars/casegen_upcars.py
@@ -161,7 +161,10 @@ def main():
         centroid_x = get_value(geometry["centroid_x"], parser.centroid_x)
         centroid_y = get_value(geometry["centroid_y"], parser.centroid_y)
         origin_x = get_value(geometry.get("origin_x", 0.0), parser.origin_x)
+        origin_x_pos = get_value(geometry.get("origin_x_pos", 0.0), parser.origin_x_pos)
         origin_y = get_value(geometry.get("origin_y", 0.0), parser.origin_y)
+        origin_y_pos = get_value(geometry.get("origin_y_pos", 0.0), parser.origin_y_pos)
+        origin_top = get_value(geometry.get("origin_top", 0.0), parser.origin_top)
         rotation = get_value(geometry.get("rotation", 0.0), parser.rotation)
 
         # Merge streak intro background matrix
@@ -419,6 +422,9 @@ def main():
         origin_x,
         origin_y,
         rotation,
+        origin_x_pos,
+        origin_y_pos,
+        origin_top,
         fracture_length_x,
         fracture_offset_x,
         fracture_height_x,

--- a/src/subscript/casegen_upcars/udf_arg_parser.py
+++ b/src/subscript/casegen_upcars/udf_arg_parser.py
@@ -570,12 +570,39 @@ def fill_parser(parser):
     )
 
     parser.add_argument(
+        "--originXPos",
+        "--origin_x_pos",
+        type=float,
+        dest="origin_x_pos",
+        required=False,
+        help="Origin position as fraction of model size in X-direction",
+    )
+
+    parser.add_argument(
         "--originY",
         "--origin_y",
         type=float,
         dest="origin_y",
         required=False,
         help="Origin coordinate of model in Y-direction",
+    )
+
+    parser.add_argument(
+        "--originYPos",
+        "--origin_y_pos",
+        type=float,
+        dest="origin_y_pos",
+        required=False,
+        help="Origin position as fraction of model size in Y-direction",
+    )
+
+    parser.add_argument(
+        "--originTop",
+        "--origin_top",
+        type=float,
+        dest="origin_top",
+        required=False,
+        help="Origin top depth",
     )
 
     parser.add_argument(

--- a/tests/test_casegen_upcars.py
+++ b/tests/test_casegen_upcars.py
@@ -235,6 +235,56 @@ def test_demo_large_scale_with_coordinate_transformation(tmp_path, mocker):
     assert data_frame.Values["rotation"] == 15.0
 
 
+def test_demo_large_scale_with_origin_shifting(tmp_path, mocker):
+    """Test casegen_upcars on demo_large_scale.yaml with coordinate transformation"""
+    shutil.copytree(DATADIR, tmp_path / TESTDATA)
+    os.chdir(tmp_path / TESTDATA)
+
+    base_name = "TEST_LARGE_WITH_ORIGIN_SHIFTING"
+    mocker.patch(
+        "sys.argv",
+        [
+            "casegen_upcars",
+            "demo_large_scale.yaml",
+            "--et",
+            "dump_value.tmpl",
+            "--origin_x_pos",
+            "0.1",
+            "--origin_y_pos",
+            "0.8",
+            "--origin_top",
+            "1000.0",
+            "--base",
+            base_name,
+        ],
+    )
+    casegen_upcars.main()
+
+    # check that all output files are generated
+    for pre, suf in zip(
+        ["", "fipnum_", "gridinc_", "satnum_", "swat_"],
+        [".DATA", ".INC", ".GRDECL", ".INC", ".INC"],
+    ):
+        assert Path(pre + base_name + suf).exists()
+        if suf != ".DATA":
+            assert opm.io.Parser().parse(str(pre + base_name + suf))
+
+    # check some key parameters in output file
+    data_frame = pd.read_csv(base_name + ".DATA", index_col=0)
+    assert data_frame.Values["nx"] == 77
+    assert data_frame.Values["ny"] == 72
+    assert data_frame.Values["nz"] == 27
+    assert data_frame.Values["lx"] == 7700.0
+    assert data_frame.Values["ly"] == 7200.0
+    assert data_frame.Values["lz"] == 355.0
+    assert data_frame.Values["poro"] == 0.1711
+    assert data_frame.Values["originX"] == 0.0
+    assert data_frame.Values["originY"] == 0.0
+    assert data_frame.Values["rotation"] == 0.0
+    assert data_frame.Values["top"] == 1000.0
+    assert data_frame.Values["bottom"] == 1355.0
+
+
 def test_demo_large_scale_with_cmdline_streaks(tmp_path, mocker):
     """Test casegen_upcars on demo_large_scale.yaml with some streaks"""
     shutil.copytree(DATADIR, tmp_path / TESTDATA)

--- a/tests/testdata_casegen_upcars/demo_large_scale.yaml
+++ b/tests/testdata_casegen_upcars/demo_large_scale.yaml
@@ -48,7 +48,12 @@ Geometry:
   origin_y: 0
   # Coordinate rotation angle in degree ('--rotation')
   rotation: 0
-
+  # The location of origin as fraction of the model lx (0 = West most - Default, 1 = East most) ('--origin_x_pos', '--originXPos')
+  origin_x_pos: 1.0
+  # The location of origin as fraction of the model ly (0 = South most - Default, 1 = North most) ('--origin_y_pos', '--originYPos')
+  origin_y_pos: 1.0
+  # The top of origin point, default = 0 in which case it's ignored and model will use top keyword, if > 0, CaseGen will ensure that the origin point will start at this depth ('--origin_top', '--originTop')
+  origin_top: 0.0
 Layers:
   Background Matrix:
     NZ : 27                   # Total number of cells in z-direction, including heterogeneous layers ('--matrix_nz)

--- a/tests/testdata_casegen_upcars/demo_small_scale.yaml
+++ b/tests/testdata_casegen_upcars/demo_small_scale.yaml
@@ -48,7 +48,12 @@ Geometry:
   origin_y: 0
   # Coordinate rotation angle in degree ('--rotation')
   rotation: 0
-
+  # The location of origin as fraction of the model lx (0 = West most - Default, 1 = East most) ('--origin_x_pos', '--originXPos')
+  origin_x_pos: 1.0
+  # The location of origin as fraction of the model ly (0 = South most - Default, 1 = North most) ('--origin_y_pos', '--originYPos')
+  origin_y_pos: 1.0
+  # The top of origin point, default = 0 in which case it's ignored and model will use top keyword, if > 0, CaseGen will ensure that the origin point will start at this depth ('--origin_top', '--originTop')
+  origin_top: 0.0
 
 Layers:
   Background Matrix:


### PR DESCRIPTION
One of the user in Equinor requested to have possibility to put the origin location in the middle of the model instead of corner. The PR will add option to put origin location at any location in the model by set the value of origin_x_pos and origin_y_pos to a value between 0 - 1 (fraction of model size in X and Y direction). In addition, user can also set the top of origin.