### PR TITLE
Sector2fluxnum optional eclipse version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
+env*/
 build/
 develop-eggs/
 dist/

--- a/src/subscript/ofmvol2csv/ofmvol2csv.py
+++ b/src/subscript/ofmvol2csv/ofmvol2csv.py
@@ -283,10 +283,7 @@ def parse_ofmtable(
             on_bad_lines="skip",  # pylint: disable=unexpected-keyword-arg
         )
 
-    if version.parse(pd.__version__) >= version.parse("2.0"):
-        data["DATE"] = pd.to_datetime(data["DATE"], format="mixed", dayfirst=True)
-    else:
-        data["DATE"] = pd.to_datetime(data["DATE"], dayfirst=True)
+    data["DATE"] = pd.to_datetime(data["DATE"], dayfirst=True)
 
     if "WELL" in data and "DATE" in data:
         data = data.set_index(["WELL", "DATE"]).sort_index()

--- a/src/subscript/ofmvol2csv/ofmvol2csv.py
+++ b/src/subscript/ofmvol2csv/ofmvol2csv.py
@@ -283,7 +283,10 @@ def parse_ofmtable(
             on_bad_lines="skip",  # pylint: disable=unexpected-keyword-arg
         )
 
-    data["DATE"] = pd.to_datetime(data["DATE"], dayfirst=True)
+    if version.parse(pd.__version__) >= version.parse("2.0"):
+        data["DATE"] = pd.to_datetime(data["DATE"], format="mixed", dayfirst=True)
+    else:
+        data["DATE"] = pd.to_datetime(data["DATE"], dayfirst=True)
 
     if "WELL" in data and "DATE" in data:
         data = data.set_index(["WELL", "DATE"]).sort_index()

--- a/src/subscript/rmsecl_volumetrics/rmsecl_volumetrics.py
+++ b/src/subscript/rmsecl_volumetrics/rmsecl_volumetrics.py
@@ -76,7 +76,7 @@ def _compare_volumetrics(
     absolute differences of eclipse volumes minus RMS volumes.
     """
     set_data_list = []
-    for set_idx, regzonfip_set in disjoint_sets_df.groupby(["SET"]):
+    for set_idx, regzonfip_set in disjoint_sets_df.groupby("SET"):
         set_results = {"SET": set_idx}
         # Slice and sum simvolumes_df for the FIPNUMS in this set:
         set_fipnums = set(regzonfip_set["FIPNUM"]).intersection(simvolumes_df.index)
@@ -88,7 +88,7 @@ def _compare_volumetrics(
             )
             continue
         set_results.update(
-            _prefix_keys("ECL_", dict(simvolumes_df.loc[set_fipnums].sum()))
+            _prefix_keys("ECL_", dict(simvolumes_df.loc[list(set_fipnums)].sum()))
         )
 
         # Slicing in multiindex requires a list of unique tuples:
@@ -104,7 +104,7 @@ def _compare_volumetrics(
             continue
         # Slice and sum RMS volumetrics:
         set_results.update(
-            _prefix_keys("RMS_", dict(volumetrics_df.loc[regzones].sum()))
+            _prefix_keys("RMS_", dict(volumetrics_df.loc[list(regzones)].sum()))
         )
 
         if "RMS_FACIES" in set_results:

--- a/src/subscript/sector2fluxnum/datafile_obj.py
+++ b/src/subscript/sector2fluxnum/datafile_obj.py
@@ -389,18 +389,13 @@ class Datafile:
         if not os.path.isfile(self.USEFLUX_name):
             raise Exception("ERROR: USEFLUX file not created!")
 
-    def run_DUMPFLUX_nosim(self, ecl_version="2014.2"):
+    def run_DUMPFLUX_nosim(self, ecl_version=None):
         # pylint: disable=invalid-name
         """
         Executes interactive ECLIPSE run with DUMPFLUX DATA file.
 
         Checks for errors in the output PRT file
         """
-
-        if ecl_version != "2014.2":
-            print(
-                f"WARNING: Not a default ECL version. ECL version is {ecl_version} ..."
-            )
 
         if not os.path.isfile(self.DUMPFLUX_name):
             raise Exception("ERROR: DUMPFLUX file not found!")
@@ -414,7 +409,11 @@ class Datafile:
                 print("Could not remove old FLUX file ", err)
                 raise
 
-        commandline = f"runeclipse -i -v {ecl_version} {self.DUMPFLUX_name}"
+        if ecl_version:
+            commandline = f"runeclipse -i -v {ecl_version} {self.DUMPFLUX_name}"
+        else:
+            commandline = f"runeclipse -i {self.DUMPFLUX_name}"
+
         args = shlex.split(commandline)
 
         # Call ECL subprocess

--- a/tests/test_csv2ofmvol.py
+++ b/tests/test_csv2ofmvol.py
@@ -274,7 +274,10 @@ def test_df2vol(dframe, expected_lines):
     # Ensure dates in the multiindes are datetime types, needed for comparison.
     if not dframe.empty:
         dframe.index = dframe.index.set_levels(
-            [dframe.index.levels[0], pd.to_datetime(dframe.index.levels[1])]
+            [
+                dframe.index.levels[0],
+                pd.to_datetime(dframe.index.levels[1], dayfirst=True),
+            ]
         )
 
     # Need to convert column names also as in ofmvol2csv for comparison:

--- a/tests/test_ofmvol2csv.py
+++ b/tests/test_ofmvol2csv.py
@@ -235,22 +235,6 @@ def test_find_wellstart_indices(inputlines, expected):
             ),
         ),
         (
-            # Pandas will mix (!!) MM.DD.YYYY if DD.MM.YYYY when necessary..
-            [
-                "*DATE *Days *Oil",
-                "*NAME A-1",
-                "01.20.1987 8.1 100",
-                "21.1.1987 9.1 200",
-            ],
-            pd.DataFrame(
-                columns=["WELL", "DATE", "DAYS", "OIL"],
-                data=[
-                    ["A-1", datetime.date(1987, 1, 20), 8.1, 100],
-                    ["A-1", datetime.date(1987, 1, 21), 9.1, 200],
-                ],
-            ),
-        ),
-        (
             # More columns:
             [
                 "*DATE *OPR *gas",
@@ -326,7 +310,7 @@ def test_parse_well(inputlines, expected):
                 "*WELL  *DATE *OPR",
                 "--  comment",
                 "A-1 2020-12-25 200",
-                '"A-2" 25.12.2020 100',
+                '"A-2" 2020-12-25 100',
             ],
             pd.DataFrame(
                 columns=["WELL", "DATE", "OPR"],

--- a/tests/test_ofmvol2csv.py
+++ b/tests/test_ofmvol2csv.py
@@ -283,10 +283,7 @@ def test_find_wellstart_indices(inputlines, expected):
                 "*DATE *Days *Oil",
                 "*NAME A-1",
             ],
-            pd.DataFrame(
-                columns=[],
-                data=[],
-            ),
+            pd.DataFrame(),
         ),
     ],
 )
@@ -367,10 +364,7 @@ def test_parse_well(inputlines, expected):
         (
             # Another empty dataset:
             ["*METRIC", "*DAILY", "*DATE *OIL"],
-            pd.DataFrame(
-                columns=[],
-                data=[],
-            ),
+            pd.DataFrame(),
         ),
         (
             [
@@ -487,7 +481,7 @@ def test_cmdline_globbing(datadir):
     assert not output.empty
     assert set(output["OFMVOLFILE"]) == {"fileA.vol", "fileB.vol", "fileC.vol"}
     assert len(output) == 17
-    assert output["WELL"].is_monotonic
+    assert output["WELL"].is_monotonic_increasing
 
     ofmvol2csv.ofmvol2csv_main(
         ["fileA.vol", "fileB.vol", "fileC.vol"],

--- a/tests/test_sector2fluxnum.py
+++ b/tests/test_sector2fluxnum.py
@@ -35,8 +35,6 @@ def test_main_test(tmp_path, mocker):
             str(input_INPUT_DUMPFLUX),
             str(input_ECL_CASE),
             str(input_OUTPUT_FLUX),
-            "--ecl_version",
-            "2014.2",
         ],
     )
     sector2fluxnum.main()
@@ -65,8 +63,6 @@ def test_main_test_fipnum(tmp_path, mocker):
             str(input_INPUT_DUMPFLUX),
             str(input_ECL_CASE),
             str(input_OUTPUT_FLUX),
-            "--ecl_version",
-            "2014.2",
         ],
     )
     sector2fluxnum.main()
@@ -101,8 +97,6 @@ def test_main_with_ecl_run(tmp_path, mocker):
             str(input_RESTART),
             str(input_ECL_CASE),
             str(input_OUTPUT_FLUX),
-            "--ecl_version",
-            "2014.2",
         ],
     )
     sector2fluxnum.main()


### PR DESCRIPTION
Make sector2fluxnum ecl_version argument optional. If ecl_version is not specified, runeclipse will run a using a default version (currently 2021.3)

Resolve #512 