### PR TITLE
sector2fluxnum: Make ecl_version argument optional

### DIFF
--- a/src/subscript/sector2fluxnum/datafile_obj.py
+++ b/src/subscript/sector2fluxnum/datafile_obj.py
@@ -389,18 +389,13 @@ class Datafile:
         if not os.path.isfile(self.USEFLUX_name):
             raise Exception("ERROR: USEFLUX file not created!")
 
-    def run_DUMPFLUX_nosim(self, ecl_version="2014.2"):
+    def run_DUMPFLUX_nosim(self, ecl_version=None):
         # pylint: disable=invalid-name
         """
         Executes interactive ECLIPSE run with DUMPFLUX DATA file.
 
         Checks for errors in the output PRT file
         """
-
-        if ecl_version != "2014.2":
-            print(
-                f"WARNING: Not a default ECL version. ECL version is {ecl_version} ..."
-            )
 
         if not os.path.isfile(self.DUMPFLUX_name):
             raise Exception("ERROR: DUMPFLUX file not found!")
@@ -414,7 +409,11 @@ class Datafile:
                 print("Could not remove old FLUX file ", err)
                 raise
 
-        commandline = f"runeclipse -i -v {ecl_version} {self.DUMPFLUX_name}"
+        if ecl_version:
+            commandline = f"runeclipse -i -v {ecl_version} {self.DUMPFLUX_name}"
+        else:
+            commandline = f"runeclipse -i {self.DUMPFLUX_name}"
+
         args = shlex.split(commandline)
 
         # Call ECL subprocess

--- a/tests/test_sector2fluxnum.py
+++ b/tests/test_sector2fluxnum.py
@@ -35,8 +35,6 @@ def test_main_test(tmp_path, mocker):
             str(input_INPUT_DUMPFLUX),
             str(input_ECL_CASE),
             str(input_OUTPUT_FLUX),
-            "--ecl_version",
-            "2014.2",
         ],
     )
     sector2fluxnum.main()
@@ -65,8 +63,6 @@ def test_main_test_fipnum(tmp_path, mocker):
             str(input_INPUT_DUMPFLUX),
             str(input_ECL_CASE),
             str(input_OUTPUT_FLUX),
-            "--ecl_version",
-            "2014.2",
         ],
     )
     sector2fluxnum.main()
@@ -101,8 +97,6 @@ def test_main_with_ecl_run(tmp_path, mocker):
             str(input_RESTART),
             str(input_ECL_CASE),
             str(input_OUTPUT_FLUX),
-            "--ecl_version",
-            "2014.2",
         ],
     )
     sector2fluxnum.main()


### PR DESCRIPTION
Make sector2fluxnum ecl_version argument optional. If ecl_version is not specified, runeclipse will run a using a default version (currently 2021.3)

Resolve #512 