### PR TITLE
Auto update version for `eclmanual` and `runeclipse`

### DIFF
--- a/src/subscript/legacy/eclmanual
+++ b/src/subscript/legacy/eclmanual
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-eclversion="2022.2"
+eclversion=$(eclrun --report-versions eclipse | xargs -n1 | sort -gr | head -1)
 export ECLPATH="/prog/res/ecl/grid"
 
 if [ "$1" == "-v" ] && [ "$2" != "" ] ; then
@@ -28,4 +28,3 @@ if [ -f $manualpath ] ; then
 else
     echo "Unable to find manuals for version $eclversion"
 fi
-

--- a/src/subscript/legacy/runeclipse
+++ b/src/subscript/legacy/runeclipse
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w 
+#!/usr/bin/perl -w
 
 use strict;
 
@@ -31,7 +31,8 @@ my $arch64 = "x86_64Linux";    # bsub resource string for 64bit
 # ---------------------------------------------------
 
 my $que_name  = "daily";
-my $version   = "2021.3";
+my $version   = `eclrun --report-versions eclipse | xargs -n1 | sort -gr | head -1`;
+chomp($version);
 my $memoryreq = 512;
 
 my $progname    = "eclipse";
@@ -518,4 +519,3 @@ sub in_error {
     }
     exit 1;
 }
-


### PR DESCRIPTION
Automatic fetch latest Eclipse version and using for `eclmanual` and `runeclipse`

The PR fetch E100 version and assumes that there is a corresponding E300 and Eclipse manual.