### PR TITLE
Set opm flow strictness to low

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -9,5 +9,5 @@ copy_test_files () {
 }
 
 start_tests () {
-    pytest --flow-simulator="/project/res/x86_64_RH_7/bin/flowrc15" --eclipse-simulator="runeclipse"
+    pytest --flow-simulator="/project/res/x86_64_RH_7/bin/flowdaily" --eclipse-simulator="runeclipse"
 }

--- a/tests/test_check_swatinit_simulators.py
+++ b/tests/test_check_swatinit_simulators.py
@@ -58,6 +58,8 @@ def run_reservoir_simulator(simulator, resmodel, perform_qc=True):
     simulator_option = []
     if "runeclipse" in simulator:
         simulator_option = ["-i"]
+    if "flow" in simulator:
+        simulator_option = ["--parsing-strictness=low"]
     result = subprocess.run(  # pylint: disable=subprocess-run-check
         [simulator] + simulator_option + ["FOO.DATA"], stdout=subprocess.PIPE
     )


### PR DESCRIPTION
The latest OPM (2023.04) has changed its behavior with regard to non-supported keywords.

Earlier version will just trigger warning and continue the simulation. In the new version, it will trigger warning and terminate t he simulation. A new command line argument `--parsing-strictness` has been added and set it to `low` will give the same behavior as in earlier version.

The PR also update `testkomodo.sh` since `flowrc15` doesn't support this new command line argument.