### PR TITLE
Unpin numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ REQUIREMENTS = [
     "ert>=2.38.0b7",
     "fmu-tools",
     "matplotlib",
-    "numpy<1.24.3",
+    "numpy",
     "opm>=2021.10",
     "packaging",
     "pandas",


### PR DESCRIPTION
After this commit https://github.com/equinor/xtgeo/commit/313473fc974f08d89bff3a3499d0a40a25fd89e7 it is possible to unpin numpy version