### PR TITLE
Give more helpful encoding exceptions in pack_sim

### DIFF
--- a/.github/workflows/subscript.yml
+++ b/.github/workflows/subscript.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests
+          pytest -n auto tests
           # Check that repository is untainted by test code:
           git status --porcelain
           test -z "$(git status --porcelain)"

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ In a fresh virtual environment you should be able to do::
 
 and all dependencies should be installed. Confirm your installation with::
 
-  pytest
+  pytest -n auto
 
 and this should run for some minutes without failures.
 

--- a/docs/contribution.rst
+++ b/docs/contribution.rst
@@ -61,7 +61,7 @@ repository, which you can do by running:
 
 .. code-block:: console
 
-  pytest
+  pytest -n auto
 
 
 Repository conventions

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ REQUIREMENTS = [
     "scipy",
     "seaborn",
     "segyio",
+    "urllib3<2",
     "xlrd",
     "xtgeo",
 ]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,6 +6,7 @@ mypy
 pytest
 pytest-cov
 pytest-mock
+pytest-xdist
 rstcheck
 rstcheck-core
 types-Jinja2


### PR DESCRIPTION
Resolves #537 

- Added pytest-xdist to parallelize the tests
- Pinned urllib3<2, as urllib3>=2 is pulled in through the dependency tree and is incompatible with RGS machines
- Gave a more helpful exception reason on utf-8 encoding errors. It roughly copies how ERT handles it but stops at the first bad character

A specific command to do the conversion _could_ be given but it's probably better not to be responsible if it damages the file.