### PR TITLE
Pin Sphinx < 7 and build without setuptools hook

### DIFF
--- a/.github/workflows/subscript.yml
+++ b/.github/workflows/subscript.yml
@@ -26,15 +26,12 @@ jobs:
 
     steps:
       - name: Checkout commit locally
-        uses: actions/checkout@v2
-
-      - name: Checkout tags
-        # This seems necessary for setuptools_scm to be able to infer
-        # the correct version.
-        run: git fetch --unshallow --tags
-
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+        
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -78,12 +75,12 @@ jobs:
         run: rstcheck -r docs
 
       - name: Build documentation
-        run: python setup.py build_sphinx
+        run: sphinx-build -b html docs build/docs/html
 
       - name: Update GitHub pages
         if: github.repository_owner == 'equinor' && github.ref == 'refs/heads/master' && matrix.python-version == '3.8'
         run: |
-          cp -R ./build/sphinx/html ../html
+          cp -R ./build/docs/html ../html
 
           git config --local user.email "subscript-github-action"
           git config --local user.name "subscript-github-action"

--- a/docs/contribution.rst
+++ b/docs/contribution.rst
@@ -144,6 +144,6 @@ Building documentation
 Assuming the developer instructions above, run the following command to to
 build the documentation for subscript::
 
-  python setup.py build_sphinx
+  sphinx-build -b html docs build/docs/html
 
 and then point your browser to the file ``build/docs/index.html``.

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,5 +1,5 @@
 autoapi
-sphinx
+sphinx<7
 sphinx-argparse
 sphinx-autodoc-typehints
 sphinx_rtd_theme


### PR DESCRIPTION
Sphinx >= 7 deprecates building docs through its setuptools hook and deprecates the `style` HTML key that is used by the sphinx_rtd_theme. The theme has not yet been updated to address this change.