### PR TITLE
fmu_copy_revision - Add empty directory test

### DIFF
--- a/src/subscript/fmu_copy_revision/fmu_copy_revision.py
+++ b/src/subscript/fmu_copy_revision/fmu_copy_revision.py
@@ -640,20 +640,7 @@ class CopyFMU:
         ]
         logger.info(" ".join(command))
 
-        if sys.version_info[1] >= 7:
-            process = subprocess.run(
-                command, check=True, shell=False, capture_output=True
-            )
-        else:
-            # capture_output is not supported in 3.6 https://www.py4u.net/discuss/195326
-            process = subprocess.run(
-                command,
-                check=True,
-                shell=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-
+        process = subprocess.run(command, check=True, shell=False, capture_output=True)
         stdout = process.stdout.decode().splitlines()
         stderr = process.stderr.decode().splitlines()
 


### PR DESCRIPTION
Resolves #428 

It seems that fmu_copy_revision runs as expected for the provided profile type. Users may not have realized the profile they selected does not copy empty directories so it may become more "fixed" with added documentation.

Regarding the comment about the contents of /output directories, it seems to have been fixed in [85ee037](https://github.com/equinor/subscript/commit/85ee037554271374031c31f8526c1e0eb6a8d0ba)