### PR TITLE
Update check_swatinit due to Flow support PPCWMAX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env*/
+venv*/
 build/
 develop-eggs/
 dist/

--- a/tests/test_check_swatinit_simulators.py
+++ b/tests/test_check_swatinit_simulators.py
@@ -103,6 +103,9 @@ def test_swat_higher_than_swatinit_via_swl_above_contact(simulator, tmp_path):
     assert pd.isnull(qc_frame["PC"][0])
 
 
+@pytest.mark.skip(
+    reason="flowdaily has supported PPCWMAX but not official release of flow",
+)
 def test_swat_limited_by_ppcwmax_above_contact(simulator, tmp_path):
     """Test PPCWMAX far above contact. This keyword is only supported by Eclipse100
     and will be ignored by flow.
@@ -749,6 +752,9 @@ def test_pc_scaled_above_gwc(eclipse_simulator, tmp_path):
     assert np.isclose(qc_frame["PC"][0], 9.396621)
 
 
+@pytest.mark.skip(
+    reason="flowdaily has supported PPCWMAX but not official release of flow",
+)
 def test_ppcwmax_gridvector(simulator, tmp_path):
     """Test that ppcwmax_gridvector maps ppcwmax values correctly in the grid"""
     os.chdir(tmp_path)
@@ -765,6 +771,9 @@ def test_ppcwmax_gridvector(simulator, tmp_path):
     assert np.isclose(qc_frame[qc_frame["SATNUM"] == 2]["PPCWMAX"].unique(), 0.02)
 
 
+@pytest.mark.skip(
+    reason="flowdaily has supported PPCWMAX but not official release of flow",
+)
 def test_ppcwmax_gridvector_eqlnum(flow_simulator, tmp_path):
     """Test that ppcwmax unrolling also works with EQLNUM (historical bug)"""
     os.chdir(tmp_path)


### PR DESCRIPTION
Latest OPM Flow (June 16 2023) supports PCCWMAX keyword. But it gives a slightly different results compare to Eclipse due to how fine the calculation is. OPM Flow seems to be more accurate in the calculation.

However, since official release flow is still 2023.04, the test will fail. Hence disable it until OPM release a new version.