### PR TITLE
Ensure /global/bin is in PATH for komodo

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -9,5 +9,6 @@ copy_test_files () {
 }
 
 start_tests () {
+    export PATH=$PATH:/global/bin  # for eclrun
     pytest --flow-simulator="/project/res/x86_64_RH_7/bin/flowdaily" --eclipse-simulator="runeclipse"
 }


### PR DESCRIPTION
The test environment in which pytest is run when doing komodo tests is limited. This commit will ensure that /global/bin in in the PATH. The added instruction is idempotent.

/global/bin is needed as it is the typical location for eclrun which runeclipse in subscript now uses to locate the needed binaries for Eclipse.