### PR TITLE
Fix issue with `eclrun` cannot find Eclipse version during testing

### DIFF
--- a/src/subscript/legacy/eclmanual
+++ b/src/subscript/legacy/eclmanual
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-eclversion=$(eclrun --report-versions eclipse | xargs -n1 | sort -gr | head -1)
 export ECLPATH="/prog/res/ecl/grid"
+eclversion=$($ECLPATH/macros/eclrun --report-versions eclipse | xargs -n1 | sort -gr | head -1)
+if [ -z "$eclversion" ] ; then
+    eclversion="2022.2";
+fi
 
 if [ "$1" == "-v" ] && [ "$2" != "" ] ; then
     eclversion=$2

--- a/src/subscript/legacy/runeclipse
+++ b/src/subscript/legacy/runeclipse
@@ -31,8 +31,10 @@ my $arch64 = "x86_64Linux";    # bsub resource string for 64bit
 # ---------------------------------------------------
 
 my $que_name  = "daily";
-my $version   = `eclrun --report-versions eclipse | xargs -n1 | sort -gr | head -1`;
+my $default_version = "2023.1";
+my $version   = `$ecldir/macros/eclrun --report-versions eclipse | xargs -n1 | sort -gr | head -1`;
 chomp($version);
+if (!$version) {$version = $default_version}
 my $memoryreq = 512;
 
 my $progname    = "eclipse";


### PR DESCRIPTION
`eclrun` cannot find the latest version string during testing. This PR will use full path for `eclrun` 

In the case that it failed to retrieve correct version, it will use 2023.1 as default version. 