### PR TITLE
Update workflows and add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/subscript
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/subscript.yml
+++ b/.github/workflows/subscript.yml
@@ -11,7 +11,7 @@ on:
     types:
       - published
   schedule:
-    # Run CI every night and check that tests are working with latest dependencies
+    # Run nightly to check that tests are working with latest dependencies
     - cron: "0 0 * * *"
 
 env:
@@ -22,14 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout commit locally
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-        
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -51,20 +51,32 @@ jobs:
 
       - name: Force correct RIPS version
         run: |
-          ResInsight --console --help | grep "ResInsight v. 2021.06" && pip install rips==2021.6.0.1 || true
-          ResInsight --console --help | grep "ResInsight v. 2020.10" && pip install rips==2020.10.0.2 || true
-
-      - name: Check code style and typing
-        run: |
-          isort --check-only --profile black src tests
-          black --check *.py src tests
-          flake8 src tests
-          mypy src/subscript
+          ResInsight --console --help | grep "ResInsight v. 2021.06" \
+            && pip install rips==2021.6.0.1 || true
+          ResInsight --console --help | grep "ResInsight v. 2020.10" \
+            && pip install rips==2020.10.0.2 || true
 
       - name: List all installed packages
         run: pip freeze
 
+      - name: Lint with isort
+        if: ${{ always() }}
+        run: isort --check-only --profile black src tests
+
+      - name: Lint with black
+        if: ${{ always() }}
+        run: black --check *.py src tests
+
+      - name: Lint with flake8
+        if: ${{ always() }}
+        run: flake8 src tests
+
+      - name: Check typing with mypy
+        if: ${{ always() }}
+        run: mypy src/subscript
+
       - name: Run tests
+        if: ${{ always() }}
         run: |
           pytest -n auto tests
           # Check that repository is untainted by test code:
@@ -72,9 +84,11 @@ jobs:
           test -z "$(git status --porcelain)"
 
       - name: Syntax check documentation
+        if: ${{ always() }}
         run: rstcheck -r docs
 
       - name: Build documentation
+        if: ${{ always() }}
         run: sphinx-build -b html docs build/docs/html
 
       - name: Update GitHub pages

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![subscript](https://github.com/equinor/subscript/actions/workflows/subscript.yml/badge.svg)](https://github.com/equinor/subscript/actions/workflows/subscript.yml)
 [![codecov](https://codecov.io/gh/equinor/subscript/branch/master/graph/badge.svg)](https://codecov.io/gh/equinor/subscript)
-![Python Version](https://img.shields.io/badge/python-3.8%20|%203.9-blue.svg)
+![Python Version](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10-blue.svg)
 [![License: GPL v3](https://img.shields.io/github/license/equinor/subscript)](https://www.gnu.org/licenses/gpl-3.0)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
@@ -21,18 +21,17 @@
 
 ## Installation
 
-subscript is not presently available on PyPI so it must be manually installed.
+subscript can be installed via pip
 
 ```sh
-git clone git@github.com:equinor/subscript
-cd subscript
-pip install .
+pip install subscript
 ```
 
 ## Usage
 
 As a collection of utilities subscript has many different invocations and
-usages. It is recommended to visit the [documentation](#documentation)
+usages. It is recommended to visit the
+[documentation](https://equinor.github.io/subscript)
 for a complete overview.
 
 Note that some of these utilities may depend upon commercial third-party

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Natural Language :: English",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
@@ -83,9 +84,9 @@ docs = [
 ]
 
 [project.urls]
-homepage = "https://github.com/equinor/subscript"
-documentation = "https://equinor.github.io/subscript"
-repository = "https://github.com/equinor/subscript"
+Homepage = "https://github.com/equinor/subscript"
+Repository = "https://github.com/equinor/subscript"
+Documentation = "https://equinor.github.io/subscript"
 
 [project.scripts]
 bjobsusers = "subscript.bjobsusers.bjobsusers:main"


### PR DESCRIPTION
subscript is now available at https://pypi.org/project/subscript/. The new workflow uses PyPI's trusted publisher mechanism which checks for the presence of `publish.yml` in this repository in this organization and does some magic to accept distributions from it without a token.

As a consequence this workflow _cannot_ be renamed without adapting the PyPI project. It is set to trigger only when a release tag is pushed -- but we should test it.

We should add another maintainer to the PyPI project for some redundancy :-)

Resolves #249
Resolves #576