### PR TITLE
Fix bug with extra INCLUDE keyword

### DIFF
--- a/src/subscript/pack_sim/pack_sim.py
+++ b/src/subscript/pack_sim/pack_sim.py
@@ -410,9 +410,7 @@ def inspect_file(
                         # Ignore comments after the include statement
                         break
                     else:
-                        new_data_file += line
-                        if "--" in line:
-                            print(line)
+                        new_data_file += include_line
         elif line_strip_no_comment == "RUNSPEC" and fmu:
             section = "runspec/"
             (packing_path / "include" / section).mkdir(exist_ok=True)

--- a/tests/test_pack_sim.py
+++ b/tests/test_pack_sim.py
@@ -35,6 +35,9 @@ def test_main(tmp_path, mocker):
     assert Path("include/reek.pvt").exists()
     assert Path("include/swof.inc").exists()
 
+    # Test that comment is process properly after INCLUDE keyword
+    assert "INCLUDE\nINCLUDE" not in Path(ECLCASE).read_text(encoding="utf8")
+
 
 def test_main_fmu(tmp_path, mocker):
     """Test the --fmu option on the command line, yielding


### PR DESCRIPTION
Fix bug with extra `INCLUDE` keyword being added when there is comment between `INCLUDE`/`GDFILE`/`IMPORT` keyword and the file to be included.

Resolve issue #583 