### PR TITLE
CO2 containment script: Make containment_polygon optional argument, minor changes to calc_type_input

### DIFF
--- a/docs/scripts/co2_containment.rst
+++ b/docs/scripts/co2_containment.rst
@@ -12,9 +12,8 @@ Calculates the amount of CO\ :sub:`2` inside and outside a given perimeter, and 
 The most common use of the script is to calculate CO\ :sub:`2` mass. Options for calculation type input:
 
 * "mass": CO\ :sub:`2` mass (kg), the default option
-* "volume_extent": CO\ :sub:`2` volume (m\ :sup:`3`), a simple calculation finding the grid cells with some CO\ :sub:`2` and summing the volume of those cells
-* "volume_actual": CO\ :sub:`2` volume (m\ :sup:`3`), an attempt to calculate a more precise representative volume of CO\ :sub:`2`
-* "volume_actual_simple": CO\ :sub:`2` volume (m\ :sup:`3`), simplified version of "volume_actual"
+* "cell_volume": CO\ :sub:`2` volume (m\ :sup:`3`), a simple calculation finding the grid cells with some CO\ :sub:`2` and summing the volume of those cells
+* "actual_volume": CO\ :sub:`2` volume (m\ :sup:`3`), an attempt to calculate a more precise representative volume of CO\ :sub:`2`
 
 CSV file example
 ----------------------------

--- a/src/subscript/co2_containment/calculate.py
+++ b/src/subscript/co2_containment/calculate.py
@@ -60,7 +60,7 @@ def calculate_co2_containment(
         hazardous_polygon (Union[Polygon,Multipolygon]): The polygon that defines
              the hazardous area
         calc_type (CalculationType): Which calculation is to be performed
-             (mass / volume_extent / volume_actual / volume_actual_simple)
+             (mass / cell_volume / actual_volume / actual_volume_simplified)
 
     Returns:
         List[ContainedCo2]
@@ -85,7 +85,7 @@ def calculate_co2_containment(
     is_inside = [x if not y else False for x, y in zip(is_contained, is_hazardous)]
     is_outside = [not x and not y for x, y in zip(is_contained, is_hazardous)]
     if co2_data.zone is None:
-        if calc_type == CalculationType.VOLUME_EXTENT:
+        if calc_type == CalculationType.CELL_VOLUME:
             return [
                 c
                 for w in co2_data.data_list
@@ -131,7 +131,7 @@ def calculate_co2_containment(
             ]
         ]
     zone_map = {z: co2_data.zone == z for z in np.unique(co2_data.zone)}
-    if calc_type == CalculationType.VOLUME_EXTENT:
+    if calc_type == CalculationType.CELL_VOLUME:
         return [
             c
             for w in co2_data.data_list

--- a/src/subscript/co2_containment/co2_calculation.py
+++ b/src/subscript/co2_containment/co2_calculation.py
@@ -35,9 +35,9 @@ class CalculationType(Enum):
     """
 
     MASS = 0
-    VOLUME_EXTENT = 1
-    VOLUME_ACTUAL = 2
-    VOLUME_ACTUAL_SIMPLE = 3
+    CELL_VOLUME = 1
+    ACTUAL_VOLUME = 2
+    ACTUAL_VOLUME_SIMPLIFIED = 3
 
     @classmethod
     def check_for_key(cls, key: str):
@@ -693,8 +693,8 @@ def _calculate_co2_data_from_source_data(
     Args:
         source_data (SourceData): Data with the information of the necessary properties
                                   for the calculation of calc_type
-        calc_type (CalculationType): Which amount is calculated (mass/volume_extent/
-                                     volume_actual/volume_actual_simple)
+        calc_type (CalculationType): Which amount is calculated (mass / cell_volume /
+                                     actual_volume / actual_volume_simpified)
         co2_molar_mass (float): CO2 molar mass - Default is 44 g/mol
         water_molar_mass (float): Water molar mass - Default is 18 g/mol
 
@@ -728,7 +728,7 @@ def _calculate_co2_data_from_source_data(
         error_text += "\nMissing: SGAS"
         raise RuntimeError(error_text)
 
-    if calc_type in (CalculationType.VOLUME_ACTUAL, CalculationType.MASS):
+    if calc_type in (CalculationType.ACTUAL_VOLUME, CalculationType.MASS):
         if source == "PFlotran":
             co2_mass_cell = _pflotran_co2mass(
                 source_data, co2_molar_mass, water_molar_mass
@@ -828,7 +828,7 @@ def _calculate_co2_data_from_source_data(
             )
         else:
             co2_amount = co2_mass_output
-    elif calc_type == CalculationType.VOLUME_EXTENT:
+    elif calc_type == CalculationType.CELL_VOLUME:
         props_idx = np.where(
             [getattr(source_data, x) is not None for x in props_check]
         )[0]

--- a/src/subscript/co2_containment/co2_containment.py
+++ b/src/subscript/co2_containment/co2_containment.py
@@ -209,12 +209,12 @@ def get_parser() -> argparse.ArgumentParser:
     path_name = pathlib.Path(__file__).name
     parser = argparse.ArgumentParser(path_name)
     parser.add_argument("grid", help="Grid (.EGRID) from which maps are generated")
-    parser.add_argument(
-        "containment_polygon",
-        help="Polygon that determines the bounds of the containment area."
-        "Can use None as input value, defining all as contained.",
-    )
     parser.add_argument("outfile", help="Output filename")
+    parser.add_argument(
+        "--containment_polygon",
+        help="Polygon that determines the bounds of the containment area."
+        "Count all CO2 as contained if polygon is not provided.",
+    )
     parser.add_argument(
         "--unrst",
         help="Path to UNRST file. Will assume same base name as grid if not provided",

--- a/src/subscript/co2_containment/co2_containment.py
+++ b/src/subscript/co2_containment/co2_containment.py
@@ -43,8 +43,8 @@ def calculate_out_of_bounds_co2(
         unrst_file (str): Path to UNRST-file
         init_file (str): Path to INIT-file
         compact (bool): Write the output to a single file as compact as possible
-        calc_type_input (str): Choose mass / volume_extent / volume_actual /
-            volume_actual_simple
+        calc_type_input (str): Choose mass / cell_volume / actual_volume /
+            actual_volume_simplified
         file_containment_polygon (str): Path to polygon defining the
             containment area
         file_hazardous_polygon (str): Path to polygon defining the
@@ -89,8 +89,8 @@ def calculate_from_co2_data(
         hazardous_polygon (shapely.geometry.Polygon): Polygon defining the
             hazardous area
         compact (bool):
-        calc_type_input (str): Choose mass / volume_extent / volume_actual /
-            volume_actual_simple
+        calc_type_input (str): Choose mass / cell_volume / actual_volume /
+            actual_volume_simplified
 
     Returns:
         pd.DataFrame
@@ -148,9 +148,8 @@ def _merge_date_rows(
 
     Args:
         data_frame (pd.DataFrame): Input data frame
-        calc_type (pd.DataFrame): Input data frame
-        calc_type_input (CalculationType): Choose mass / volume_extent /
-            volume_actual / volume_actual_simple from enum CalculationType
+        calc_type (CalculationType): Choose mass / cell_volume /
+            actual_volume / actual_volume_simplified from enum CalculationType
 
     Returns:
         pd.DataFrame: Output data frame
@@ -165,7 +164,7 @@ def _merge_date_rows(
         .rename(columns={"amount": "total"})
     )
     total_df = df1.copy()
-    if calc_type == CalculationType.VOLUME_EXTENT:
+    if calc_type == CalculationType.CELL_VOLUME:
         df2 = data_frame.drop("phase", axis=1).groupby(["location", "date"]).sum()
         df2a = df2.loc[("contained",)].rename(columns={"amount": "total_contained"})
         df2b = df2.loc[("outside",)].rename(columns={"amount": "total_outside"})
@@ -236,8 +235,7 @@ def get_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--calc_type_input",
-        help="CO2 calculation options: mass / volume_extent / volume_actual / \
-             volume_actual_simple",
+        help="CO2 calculation options: mass / cell_volume / actual_volume",
         default="mass",
     )
     parser.add_argument(

--- a/tests/test_co2_calculate.py
+++ b/tests/test_co2_calculate.py
@@ -239,14 +239,14 @@ def test_reek_grid():
 
     volumes = _calculate_co2_data_from_source_data(
         source_data,
-        CalculationType.VOLUME_ACTUAL_SIMPLE,
+        CalculationType.ACTUAL_VOLUME_SIMPLIFIED,
     )
     table2 = calculate_from_co2_data(
         co2_data=volumes,
         containment_polygon=reek_poly,
         hazardous_polygon=reek_poly_hazardous,
         compact=False,
-        calc_type_input="volume_actual_simple",
+        calc_type_input="actual_volume_simplified",
     )
     assert table2.total.values[0] == pytest.approx(358.1699999999088)
     assert table2.total_gas.values[0] == pytest.approx(35.81700000000973)


### PR DESCRIPTION
Only minor changes.

Renaming options for calc_type_input.

Change containment_polygon from required to optional argument. If not provided (=None, the default), we will count all cells as contained.