### PR TITLE
Fix matplotlib type annotations

### DIFF
--- a/src/subscript/check_swatinit/plotter.py
+++ b/src/subscript/check_swatinit/plotter.py
@@ -88,7 +88,7 @@ def visual_depth(qc_frame: pd.DataFrame) -> float:
 
 
 def swat_depth(
-    qc_frame: pd.DataFrame, axis: pyplot.Axes = None, hue: str = "QC_FLAG"
+    qc_frame: pd.DataFrame, axis: Optional[pyplot.Axes] = None, hue: str = "QC_FLAG"
 ) -> None:
     """Make a SWAT vs depth plot on current axis"""
     if axis is None:
@@ -103,7 +103,7 @@ def swat_depth(
 
 
 def swatinit_depth(
-    qc_frame: pd.DataFrame, axis: pyplot.Axes = None, hue: str = "QC_FLAG"
+    qc_frame: pd.DataFrame, axis: Optional[pyplot.Axes] = None, hue: str = "QC_FLAG"
 ) -> None:
     """Make a swatinit vs depth plot on current axis"""
     if axis is None:
@@ -118,7 +118,7 @@ def swatinit_depth(
 
 
 def pressure_depth(
-    qc_frame: pd.DataFrame, axis: pyplot.Axes = None, hue: str = "QC_FLAG"
+    qc_frame: pd.DataFrame, axis: Optional[pyplot.Axes] = None, hue: str = "QC_FLAG"
 ) -> None:
     """Make a pressure vs. depth plot on current axis"""
     if axis is None:
@@ -133,7 +133,7 @@ def pressure_depth(
 
 
 def pc_depth(
-    qc_frame: pd.DataFrame, axis: pyplot.Axes = None, hue: str = "QC_FLAG"
+    qc_frame: pd.DataFrame, axis: Optional[pyplot.Axes] = None, hue: str = "QC_FLAG"
 ) -> None:
     """Make a pc vs depth plot on current axis"""
     if axis is None:

--- a/src/subscript/sw_model_utilities/sw_model_utilities.py
+++ b/src/subscript/sw_model_utilities/sw_model_utilities.py
@@ -175,7 +175,7 @@ def plotting(
         if swirra[ix] > 0.0:
             plt.plot(np.zeros(hei.size) + swirra[ix], hei, "--", color="grey")
 
-    plt.axis([0, 1, 0, hmax])
+    plt.axis((0, 1, 0, hmax))
     plt.legend(loc="upper right", shadow=True, fontsize=10)
     plt.xlabel("$S_w$")
     plt.ylabel("Height above FWL")


### PR DESCRIPTION
matplotlib 3.8.0 was released for Python 3.9 and above and includes type annotations in its public APIs. mypy failed on a call to `axis` and raised some notes about optional arguments.