### PR TITLE
Remove protobuf as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
     "opm>=2021.10",
     "packaging",
     "pandas",
-    "protobuf",
     "pyscal",
     "pyyaml",
     "rips",


### PR DESCRIPTION
It is pulled in through the dependency chain but is not a first class dependency.

Resolves #598 