### PR TITLE
Update dependencies and linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,5 @@
 [flake8]
 max-line-length = 88
 ignore = E203, W503
+per-file-ignores =
+    src/subscript/version.py:E501

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "matplotlib",
     "numpy<2",
     "opm>=2021.10",
-    "packaging",
     "pandas",
     "pyscal",
     "pyyaml",

--- a/src/subscript/ofmvol2csv/ofmvol2csv.py
+++ b/src/subscript/ofmvol2csv/ofmvol2csv.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import List, Union
 
 import pandas as pd
-from packaging import version
 
 from subscript import __version__
 from subscript import getLogger as subscriptlogger
@@ -265,24 +264,13 @@ def parse_ofmtable(
 
     assert "DATE" in columnnames
 
-    if version.parse(pd.__version__) < version.parse("1.3.0"):
-        data = pd.read_table(
-            io.StringIO(ofmstring),
-            skiprows=1,
-            sep=r"\s+",
-            names=columnnames,
-            # The following option is deprecated from Pandas 1.3.0:
-            error_bad_lines=False,
-        )
-    else:
-        data = pd.read_table(
-            io.StringIO(ofmstring),
-            skiprows=1,
-            sep=r"\s+",
-            names=columnnames,
-            on_bad_lines="skip",  # pylint: disable=unexpected-keyword-arg
-        )
-
+    data = pd.read_table(
+        io.StringIO(ofmstring),
+        skiprows=1,
+        sep=r"\s+",
+        names=columnnames,
+        on_bad_lines="skip",  # pylint: disable=unexpected-keyword-arg
+    )
     data["DATE"] = pd.to_datetime(data["DATE"], dayfirst=True)
 
     if "WELL" in data and "DATE" in data:


### PR DESCRIPTION
In addition to the fixes in the commits, I spent some time trying to reproduce the below referenced issue. I tested against the old versions of pandas before and after 2022.05.00 Komodo (1.3.4 - 1.4), as well as with pandas 2, and against the historical versions of the test case observation file given as an example in the issue. All tests pass and they produce equivalent output files. But I could not reproduce the warning.

All tests pass with pandas 2 and no warnings are issued, so I think we are OK with respect to that.

Resolves #479