### PR TITLE
Use all accessible ports for ERT on local queue

### DIFF
--- a/tests/test_check_swatinit.py
+++ b/tests/test_check_swatinit.py
@@ -766,7 +766,9 @@ def test_ert_integration(tmp_path):
         ),
         encoding="utf8",
     )
-    subprocess.run(["ert", "test_run", "test.ert"], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", "test.ert"], check=True
+    )
     # Testing the default OUTPUT:
     qc_frame = pd.read_csv("check_swatinit.csv")
     assert not qc_frame.empty
@@ -788,7 +790,9 @@ def test_ert_integration(tmp_path):
         ),
         encoding="utf8",
     )
-    subprocess.run(["ert", "test_run", "test-output.ert"], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", "test-output.ert"], check=True
+    )
     qc_frame = pd.read_csv("foo.csv")
     assert not qc_frame.empty
 

--- a/tests/test_csv2ofmvol.py
+++ b/tests/test_csv2ofmvol.py
@@ -443,7 +443,9 @@ def test_ert_hook(datadir):
     ert_config_fname = "test.ert"
     Path(ert_config_fname).write_text("\n".join(ert_config), encoding="utf8")
 
-    subprocess.run(["ert", "test_run", ert_config_fname], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", ert_config_fname], check=True
+    )
 
     assert Path("proddata.vol").exists()
     lines = Path("proddata.vol").read_text(encoding="utf8").splitlines()

--- a/tests/test_csv_merge.py
+++ b/tests/test_csv_merge.py
@@ -265,7 +265,9 @@ def test_ert_hook(tmp_path):
     ert_config_fname = "test.ert"
     Path(ert_config_fname).write_text("\n".join(ert_config), encoding="utf8")
 
-    subprocess.run(["ert", "test_run", ert_config_fname], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", ert_config_fname], check=True
+    )
 
     assert Path("merged.csv").exists()
     dframe = pd.read_csv("merged.csv")

--- a/tests/test_csv_stack.py
+++ b/tests/test_csv_stack.py
@@ -268,7 +268,9 @@ def test_ert_forward_model(tmp_path):
     ert_config_fname = "stacktest.ert"
     Path(ert_config_fname).write_text("\n".join(ert_config), encoding="utf8")
 
-    subprocess.run(["ert", "test_run", ert_config_fname], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", ert_config_fname], check=True
+    )
 
     dframe = pd.read_csv("stacked.csv")
     assert not dframe.empty
@@ -299,7 +301,9 @@ def test_ert_forward_model_keepminimal(tmp_path):
     ert_config_fname = "stacktest.ert"
     Path(ert_config_fname).write_text("\n".join(ert_config), encoding="utf8")
 
-    subprocess.run(["ert", "test_run", ert_config_fname], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", ert_config_fname], check=True
+    )
 
     dframe = pd.read_csv("stacked.csv")
     assert not dframe.empty
@@ -330,7 +334,9 @@ def test_ert_forward_model_keepconstants(tmp_path):
     ert_config_fname = "stacktest.ert"
     Path(ert_config_fname).write_text("\n".join(ert_config), encoding="utf8")
 
-    subprocess.run(["ert", "test_run", ert_config_fname], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", ert_config_fname], check=True
+    )
 
     dframe = pd.read_csv("stacked.csv")
     assert not dframe.empty
@@ -371,7 +377,9 @@ def test_csv_stack_ert_workflow(tmp_path):
         ),
         encoding="utf8",
     )
-    subprocess.run(["ert", "test_run", "test.ert"], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", "test.ert"], check=True
+    )
 
     assert Path("stacked.csv").is_file()
     pd.testing.assert_frame_equal(

--- a/tests/test_fmuobs.py
+++ b/tests/test_fmuobs.py
@@ -381,7 +381,9 @@ def test_ert_workflow_hook(verbose, tmp_path):
     ert_config_fname = "test.ert"
     Path(ert_config_fname).write_text("\n".join(ert_config), encoding="utf8")
 
-    subprocess.run(["ert", "test_run", ert_config_fname], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", ert_config_fname], check=True
+    )
 
     assert Path("ert-obs.yml").exists()
     assert Path("ri-obs.csv").exists()

--- a/tests/test_merge_rft_ertobs.py
+++ b/tests/test_merge_rft_ertobs.py
@@ -180,7 +180,9 @@ def test_ert_hook(drogondata):
     ert_config_fname = "mergetest.ert"
     Path(ert_config_fname).write_text("\n".join(ert_config), encoding="utf8")
 
-    subprocess.run(["ert", "test_run", ert_config_fname], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", ert_config_fname], check=True
+    )
 
     dframe = pd.read_csv("mergedrft.csv")
     # pylint: disable=no-member  # false positive on Pandas objects

--- a/tests/test_ofmvol2csv.py
+++ b/tests/test_ofmvol2csv.py
@@ -522,7 +522,9 @@ def test_ert_hook(datadir):
     ert_config_fname = "test.ert"
     Path(ert_config_fname).write_text("\n".join(ert_config), encoding="utf8")
 
-    subprocess.run(["ert", "test_run", ert_config_fname], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", ert_config_fname], check=True
+    )
 
     assert Path("proddata.csv").exists()
 

--- a/tests/test_prtvol2csv.py
+++ b/tests/test_prtvol2csv.py
@@ -462,7 +462,9 @@ def test_ert_forward_model(tmp_path):
         ),
         encoding="utf8",
     )
-    subprocess.run(["ert", "test_run", "test.ert"], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", "test.ert"], check=True
+    )
     assert Path("sim.csv").is_file()
 
 
@@ -499,7 +501,9 @@ def test_ert_forward_model_backwards_compat_deprecation(tmp_path):
         ),
         encoding="utf8",
     )
-    subprocess.run(["ert", "test_run", "test.ert"], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", "test.ert"], check=True
+    )
     assert Path("share/results/volumes/simulator_volume_fipnum.csv").is_file()
     stdout = Path("PRTVOL2CSV.stdout.0").read_text(encoding="utf8")
     stderr = Path("PRTVOL2CSV.stderr.0").read_text(encoding="utf8")

--- a/tests/test_ri_wellmod.py
+++ b/tests/test_ri_wellmod.py
@@ -227,7 +227,9 @@ def test_ert_forward_model(tmp_path):
     ert_config_fname = "riwmtest.ert"
     Path(ert_config_fname).write_text("\n".join(ert_config), encoding="utf8")
 
-    subprocess.run(["ert", "test_run", ert_config_fname], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", ert_config_fname], check=True
+    )
 
     assert Path(outfile).exists()
 

--- a/tests/test_sunsch.py
+++ b/tests/test_sunsch.py
@@ -925,5 +925,7 @@ def test_ert_forward_model(testdata):
         ),
         encoding="utf8",
     )
-    subprocess.run(["ert", "test_run", "test.ert"], check=True)
+    subprocess.run(
+        ["ert", "test_run", "--port-range", "1024-65535", "test.ert"], check=True
+    )
     assert Path("schedule.inc").is_file()


### PR DESCRIPTION
If not, ERT will pick a port in the default range 51820-51840 for which should be saved for ERT runs over the network. When running tests in parallel, using the limited range exposes the tests to port starvation.