### PR TITLE
`fmuobs` Warning when using ERROR_MODE != ABS

### DIFF
--- a/src/subscript/fmuobs/fmuobs.py
+++ b/src/subscript/fmuobs/fmuobs.py
@@ -348,7 +348,7 @@ def fmuobs(
 
     # Trigger warning if user specify ERROR_MODE != ABS
     # in BLOCK_OBSERVATION and SUMMARY_OBSERVATION
-    if "ERROR_MODE" in dframe.columns:
+    if isinstance(dframe, pd.DataFrame) and "ERROR_MODE" in dframe.columns:
         error_mode = list(
             dframe[
                 (dframe["CLASS"].isin(["BLOCK_OBSERVATION", "SUMMARY_OBSERVATION"]))
@@ -359,7 +359,8 @@ def fmuobs(
         )
         if len(error_mode) > 0:
             logger.warn(
-                f"Unsupported ERROR_MODE : {', '.join(error_mode)}. Please verify the output file"
+                f"Unsupported ERROR_MODE : {', '.join(error_mode)}. "
+                "Please verify the output file"
             )
 
     dump_results(dframe, csv, yml, resinsight, ertobs)

--- a/src/subscript/fmuobs/fmuobs.py
+++ b/src/subscript/fmuobs/fmuobs.py
@@ -346,6 +346,22 @@ def fmuobs(
     if not validate_internal_dframe(dframe):
         logger.error("Observation dataframe is invalid!")
 
+    # Trigger warning if user specify ERROR_MODE != ABS
+    # in BLOCK_OBSERVATION and SUMMARY_OBSERVATION
+    if "ERROR_MODE" in dframe.columns:
+        error_mode = list(
+            dframe[
+                (dframe["CLASS"].isin(["BLOCK_OBSERVATION", "SUMMARY_OBSERVATION"]))
+                & (dframe["ERROR_MODE"] != "ABS")
+            ]["ERROR_MODE"]
+            .dropna()
+            .unique()
+        )
+        if len(error_mode) > 0:
+            logger.warn(
+                f"Unsupported ERROR_MODE : {', '.join(error_mode)}. Please verify the output file"
+            )
+
     dump_results(dframe, csv, yml, resinsight, ertobs)
 
 


### PR DESCRIPTION
ERT observation config is re-using ERROR keyword to store either absolute error value or relative error value (depending on ERROR_MODE)

However, the logic is not transferred when converting to ResInsight (csv) and probably Webviz (yml) which means if user specify 10% relative error in OBS config file. ResInsight will see it as 10 in absolute error value.

At this stage, trigger the warning when user is using ERROR_MODE that is no ABS.

The logic will be implemented in another PR.