### PR TITLE
Use res2df instead of ecl2df

### DIFF
--- a/docs/scripts/prtvol2csv.rst
+++ b/docs/scripts/prtvol2csv.rst
@@ -130,5 +130,5 @@ file has been supplied defining the map from zones and regions to FIPNUM:
 See also
 --------
 
-* https://equinor.github.io/ecl2df/usage/fipreports.html can be used to extract
+* https://equinor.github.io/res2df/usage/fipreports.html can be used to extract
   more information from  the PRT files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = ["version"]
 dependencies = [
     "configsuite",
     "resdata",
-    "ecl2df",
+    "res2df",
     "ert>=2.38.0b7",
     "fmu-tools",
     "matplotlib",

--- a/src/subscript/interp_relperm/interp_relperm.py
+++ b/src/subscript/interp_relperm/interp_relperm.py
@@ -11,7 +11,7 @@ import pyscal
 import yaml
 from configsuite import MetaKeys as MK  # lgtm [py/import-and-import-from]
 from configsuite import types  # lgtm [py/import-and-import-from]
-from ecl2df import satfunc
+from res2df import satfunc
 
 import subscript
 
@@ -397,10 +397,10 @@ def main() -> None:
 
     logger.setLevel(logging.INFO)
 
-    # Mute expected warnings from ecl2df.inferdims, we get these
+    # Mute expected warnings from res2df.inferdims, we get these
     # because we don't tell the module how many SATNUMs there are in
     # input files, which is slightly fragile for opm to parse.
-    logging.getLogger("ecl2df.inferdims").setLevel(logging.ERROR)
+    logging.getLogger("res2df.inferdims").setLevel(logging.ERROR)
 
     # parse the config file
     if not Path(args.configfile).exists():

--- a/src/subscript/presentvalue/presentvalue.py
+++ b/src/subscript/presentvalue/presentvalue.py
@@ -5,9 +5,9 @@ import logging
 from pathlib import Path
 from typing import Dict, Optional
 
-import ecl2df
 import numpy as np
 import pandas as pd
+import res2df
 import scipy.optimize
 
 from subscript import __version__, getLogger
@@ -422,8 +422,8 @@ def get_yearly_summary(
         vec.split(":")[0].endswith("T") for vec in [oilvector, gasvector, gasinjvector]
     ):
         raise ValueError("Only cumulative Eclipse vectors can be used")
-    eclfiles = ecl2df.EclFiles(eclfile)
-    sum_df = ecl2df.summary.df(
+    eclfiles = res2df.ResdataFiles(eclfile)
+    sum_df = res2df.summary.df(
         eclfiles, column_keys=[oilvector, gasvector, gasinjvector], time_index="yearly"
     )
     sum_df.rename(

--- a/src/subscript/prtvol2csv/prtvol2csv.py
+++ b/src/subscript/prtvol2csv/prtvol2csv.py
@@ -7,8 +7,8 @@ import warnings
 from pathlib import Path
 from typing import Optional
 
-import ecl2df
 import pandas as pd
+import res2df
 from fmu.tools.fipmapper.fipmapper import FipMapper
 
 from subscript import __version__, getLogger
@@ -162,7 +162,7 @@ def currently_in_place_from_prt(
 ) -> pd.DataFrame:
     """Extracts currently-in-place volumes from a PRT file
 
-    This function uses ecl2df.fipreports, and slices its
+    This function uses res2df.fipreports, and slices its
     output for the purpose here.
 
     Args:
@@ -174,7 +174,7 @@ def currently_in_place_from_prt(
     Returns:
         pd.DataFrame
     """
-    inplace_df = ecl2df.fipreports.df(prt_file, fipname=fipname)
+    inplace_df = res2df.fipreports.df(prt_file, fipname=fipname)
 
     available_dates = inplace_df.sort_values("DATE")["DATE"].unique()
     if date is None or date == "first":

--- a/src/subscript/sector2fluxnum/completions.py
+++ b/src/subscript/sector2fluxnum/completions.py
@@ -1,4 +1,4 @@
-from ecl2df import EclFiles, compdat
+from res2df import ResdataFiles, compdat
 
 
 def get_completion_list(ecl_data_file_name):
@@ -14,7 +14,7 @@ def get_completion_list(ecl_data_file_name):
     List of completions associated to well names
     """
 
-    ecl_file = EclFiles(ecl_data_file_name)
+    ecl_file = ResdataFiles(ecl_data_file_name)
     compdat_df = compdat.df(ecl_file)
 
     # Convert from ECL index

--- a/tests/test_check_swatinit_simulators.py
+++ b/tests/test_check_swatinit_simulators.py
@@ -13,10 +13,10 @@ import subprocess
 import time
 from pathlib import Path
 
-import ecl2df
 import numpy as np
 import pandas as pd
 import pytest
+import res2df
 
 from subscript.check_swatinit.check_swatinit import (
     __HC_BELOW_FWL__,
@@ -85,7 +85,7 @@ def run_reservoir_simulator(simulator, resmodel, perform_qc=True):
         raise AssertionError(f"reservoir simulator failed in {os.getcwd()}")
 
     if perform_qc:
-        return make_qc_gridframe(ecl2df.EclFiles("FOO.DATA"))
+        return make_qc_gridframe(res2df.ResdataFiles("FOO.DATA"))
     return None
 
 
@@ -494,7 +494,7 @@ def test_swatinit_less_than_1_below_contact(simulator, tmp_path):
         assert np.isclose(qc_frame["PC"], 0)
     else:
         # E100 will not report a PPCW in this case, libecl gives -1e20,
-        # which becomes a NaN through ecl2df and then NaN columns are dropped.
+        # which becomes a NaN through res2df and then NaN columns are dropped.
         if "PPCW" in qc_frame:
             assert pd.isnull(qc_frame["PPCW"][0])
         if "PC_SCALING" in qc_frame:

--- a/tests/test_interp_relperm.py
+++ b/tests/test_interp_relperm.py
@@ -6,9 +6,9 @@ import configsuite
 import pandas as pd
 import pytest
 import yaml
-from ecl2df import satfunc
 from pyscal import PyscalFactory
 from pyscal.utils.testing import sat_table_str_ok
+from res2df import satfunc
 
 from subscript.interp_relperm import interp_relperm
 
@@ -201,7 +201,7 @@ def test_garbled_base_input(tmp_path):
 
 def test_parse_satfunc_files():
     """Test that tables in Eclipse format can be converted
-    into dataframes (using ecl2df)"""
+    into dataframes (using res2df)"""
     swoffn = TESTDATA / "swof_base.inc"
     sgoffn = TESTDATA / "sgof_base.inc"
 

--- a/tests/test_presentvalue.py
+++ b/tests/test_presentvalue.py
@@ -3,10 +3,10 @@ import shutil
 import subprocess
 from pathlib import Path
 
-import ecl2df
 import numpy as np
 import pandas as pd
 import pytest
+import res2df
 from resdata.summary import Summary
 
 from subscript.presentvalue import presentvalue
@@ -328,7 +328,7 @@ def test_no_gasinj(tmp_path):
     )
     smry["DATE"] = pd.to_datetime(smry["DATE"])
     smry.set_index("DATE")
-    eclsum = ecl2df.summary.df2eclsum(smry, "NOGASINJ")
+    eclsum = res2df.summary.df2ressum(smry, "NOGASINJ")
     Summary.fwrite(eclsum)
     econ_df = presentvalue.prepare_econ_table(
         oilprice=100, gasprice=0, usdtonok=10, discountrate=0
@@ -353,7 +353,7 @@ def test_no_gas(tmp_path):
     )
     smry["DATE"] = pd.to_datetime(smry["DATE"])
     smry.set_index("DATE")
-    eclsum = ecl2df.summary.df2eclsum(smry, "NOGAS")
+    eclsum = res2df.summary.df2ressum(smry, "NOGAS")
     Summary.fwrite(eclsum)
     econ_df = presentvalue.prepare_econ_table(
         oilprice=100, gasprice=0, usdtonok=10, discountrate=0
@@ -378,7 +378,7 @@ def test_no_oil(tmp_path):
     )
     smry["DATE"] = pd.to_datetime(smry["DATE"])
     smry.set_index("DATE")
-    eclsum = ecl2df.summary.df2eclsum(smry, "NOOIL")
+    eclsum = res2df.summary.df2ressum(smry, "NOOIL")
     Summary.fwrite(eclsum)
     econ_df = presentvalue.prepare_econ_table(
         oilprice=0, gasprice=10, usdtonok=10, discountrate=0


### PR DESCRIPTION
Hello from SCOUT, this is relating to the rename of ecl2df to res2df, I think this covers most of it but please double check it if something seems to be missing. 