### PR TITLE
Remove deprecated support for implicit mkdir in sunsch

### DIFF
--- a/src/subscript/sunsch/sunsch.py
+++ b/src/subscript/sunsch/sunsch.py
@@ -12,7 +12,6 @@ import logging
 import sys
 import tempfile
 import textwrap
-import warnings
 from pathlib import Path
 from typing import List, Union
 
@@ -753,13 +752,7 @@ def main():
         logger.info("Writing Eclipse deck to %s", str(config.snapshot.output))
         dirname = Path(config.snapshot.output).parent
         if dirname and not dirname.exists():
-            warnings.warn(
-                f"Implicit mkdir of directory {str(dirname)} is deprecated and "
-                f"will be removed later. Please ensure {str(dirname)} exists before "
-                "calling sunsch.",
-                FutureWarning,
-            )
-            dirname.mkdir()
+            raise OSError(f"The directory {dirname} does not exist")
         Path(config.snapshot.output).write_text(schedule, encoding="utf8")
 
 

--- a/tests/test_sunsch.py
+++ b/tests/test_sunsch.py
@@ -84,8 +84,8 @@ def test_cmdline_output(testdata, mocker):
     mocker.patch(
         "sys.argv", ["sunsch", "--output", "subdir/schedule.inc", "config_v2.yml"]
     )
-    with pytest.warns(FutureWarning, match="Implicit mkdir"):
-        sunsch.main()
+    Path("subdir").mkdir()
+    sunsch.main()
     assert Path("subdir/schedule.inc").exists()
 
 


### PR DESCRIPTION
Has been deprectated for three years, 8bfc5bd78a31c3511e82bc2325fe186f7d165833