### PR TITLE
Don't import from top-level ert module

### DIFF
--- a/src/subscript/csv_merge/csv_merge.py
+++ b/src/subscript/csv_merge/csv_merge.py
@@ -8,7 +8,7 @@ import sys
 from typing import Dict, List, Optional
 
 import pandas as pd
-from ert import ErtScript
+from ert.config import ErtScript
 from ert.shared.plugins.plugin_manager import hook_implementation  # type: ignore
 
 from subscript import __version__, getLogger

--- a/src/subscript/csv_stack/csv_stack.py
+++ b/src/subscript/csv_stack/csv_stack.py
@@ -8,7 +8,7 @@ import warnings
 from typing import Pattern
 
 import pandas as pd
-from ert import ErtScript
+from ert.config import ErtScript
 from ert.shared.plugins.plugin_manager import hook_implementation  # type: ignore
 
 from subscript import __version__, getLogger

--- a/src/subscript/fmuobs/fmuobs.py
+++ b/src/subscript/fmuobs/fmuobs.py
@@ -10,7 +10,7 @@ from typing import Optional, Tuple, Union
 
 import pandas as pd
 import yaml
-from ert import ErtScript
+from ert.config import ErtScript
 from ert.shared.plugins.plugin_manager import hook_implementation  # type: ignore
 
 from subscript import __version__, getLogger

--- a/src/subscript/params2csv/params2csv.py
+++ b/src/subscript/params2csv/params2csv.py
@@ -11,7 +11,7 @@ import shutil
 from glob import glob
 
 import pandas as pd
-from ert import ErtScript
+from ert.config import ErtScript
 from ert.shared.plugins.plugin_manager import hook_implementation  # type: ignore
 
 from subscript import __version__, getLogger


### PR DESCRIPTION
This is to speed up importing selected submodules of `ert`.