### PR TITLE
Fix bug for integers in sunsch substitute

### DIFF
--- a/src/subscript/sunsch/sunsch.py
+++ b/src/subscript/sunsch/sunsch.py
@@ -50,7 +50,7 @@ class InsertStatement(BaseModel):
     template: Optional[FilePath] = None
     days: Optional[float] = None
     string: Optional[str] = None
-    substitute: Optional[Dict[str, Union[str, float, str]]] = None
+    substitute: Optional[Dict[str, Union[int, float, str]]] = None
 
 
 class SunschConfig(BaseModel):

--- a/tests/test_sunsch.py
+++ b/tests/test_sunsch.py
@@ -60,8 +60,8 @@ def test_main(testdata, caplog, mocker):
     # Check for foo1.sch, A-1 should occur twice
     assert sum("A-1" in x for x in schlines) == 2
 
-    # Check for substitutetest:
-    assert any("400000" in x for x in schlines)
+    # Check for substitutetest, the last 1 has to be integer as it is a table index:
+    assert any("'A-90' 'OPEN' 'ORAT' 3000 0 400000 1 /" in x for x in schlines)
 
     # Check for randomid:
     assert any("A-4" in x for x in schlines)

--- a/tests/testdata_sunsch/config.yml
+++ b/tests/testdata_sunsch/config.yml
@@ -41,7 +41,7 @@ insert:
   -
     template: footemplate.sch
     days:  2
-    substitute: {ORAT: 3000, GRAT: 400000}
+    substitute: {ORAT: 3000, GRAT: 400000, VFP: 1}
     #  -
     # template: footemplate.sch
     #days: 4

--- a/tests/testdata_sunsch/footemplate.sch
+++ b/tests/testdata_sunsch/footemplate.sch
@@ -1,3 +1,3 @@
 WCONHIST
- 'A-90' 'OPEN' 'ORAT' <ORAT> <GRAT> /
+ 'A-90' 'OPEN' 'ORAT' <ORAT> 0 <GRAT> <VFP>/
 /


### PR DESCRIPTION
Resolves #665 

The issue was that certain inputs have to be `int` to be parsed by `opm`, e.g. the VFP table number (added it to the test). 
Probably just a typo in the conversion to `pydantic` as `str` was repeated twice in the typing.