### PR TITLE
Unpin urllib3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "seaborn",
     "segyio",
     "shapely",
-    "urllib3<2",
     "xlrd",
     "xtgeo",
 ]


### PR DESCRIPTION
Prefer to have komodo restrict the necessary urllib3 version for specific rhel versions.