### PR TITLE
Pin sphinx-argparse<0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ tests = [
 docs = [
     "autoapi",
     "sphinx",
-    "sphinx-argparse",
+    "sphinx-argparse<0.5.0",
     "sphinx-autodoc-typehints",
     "sphinx-copybutton",
     "sphinx-togglebutton",


### PR DESCRIPTION
Pin sphinx-argparse to < 0.5.0 due to this issue https://github.com/sphinx-doc/sphinx-argparse/issues/56
