### PR TITLE
Remove root option and add dates as include_from file

### DIFF
--- a/docs/scripts/grav_subs_maps.rst
+++ b/docs/scripts/grav_subs_maps.rst
@@ -18,7 +18,7 @@ it is possible to include them from another yaml file:
   input:
     diffdates: !include_from global_variables.yml::global.dates.GRAVITY_DIFFDATES
 
-This is an advantage if the dates in the global config is used also for other jobs. In this case the included file looks like this:
+This is an advantage if the dates in the global config is used also for other jobs. In this example the included file looks like this:
 
 .. code-block:: yaml
 
@@ -32,7 +32,7 @@ This is an advantage if the dates in the global config is used also for other jo
 The output files
 ----------------
 
-The output from this job are maps in irap binary format. For each difference data there will be one subsidence map and one or more gravity change maps (depending on which phases are specified to model).
+The output from this job are maps in irap binary format. For each difference date there will be one subsidence map and one or more gravity change maps (depending on which phases are specified to model).
 
 The naming of the output files have been standardised to:
 

--- a/docs/scripts/grav_subs_maps.rst
+++ b/docs/scripts/grav_subs_maps.rst
@@ -7,4 +7,40 @@ GRAV_SUBS_MAPS
    :func: get_parser
    :prog: grav_subs_maps
 	
+Include dates
+-------------
+
+Instead of specifying the modelling dates directly in the yaml config file
+it is possible to include them from another yaml file:
+
+.. code-block:: text
+
+  input:
+    diffdates: !include_from global_variables.yml::global.dates.GRAVITY_DIFFDATES
+
+This is an advantage if the dates in the global config is used also for other jobs. In this case the included file looks like this:
+
+.. code-block:: yaml
+
+  # example global config file with dates
+  global:
+    dates:
+      GRAVITY_DIFFDATES:
+      - - 2020-07-01
+        - 2018-01-01
    
+The output files
+----------------
+
+The output from this job are maps in irap binary format. For each difference data there will be one subsidence map and one or more gravity change maps (depending on which phases are specified to model).
+
+The naming of the output files have been standardised to:
+
+| all--subsidence--yyyymmdd_yyyymmdd.gri
+
+| all--delta_gravity_gas--yyyymmdd_yyyymmdd.gri
+| all--delta_gravity_oil--yyyymmdd_yyyymmdd.gri
+| all--delta_gravity_water--yyyymmdd_yyyymmdd.gri
+| all--delta_gravity_total--yyyymmdd_yyyymmdd.gri
+
+The "all" prefix is indicating that the contributions from all zones is summed.    

--- a/docs/scripts/grav_subs_points.rst
+++ b/docs/scripts/grav_subs_points.rst
@@ -6,6 +6,30 @@ GRAV_SUBS_POINTS
    :func: get_parser
    :prog: grav_subs_points
 
+	  
+Include dates
+-------------
+
+Instead of specifying the modelling dates directly in the yaml config file
+it is possible to include them from another yaml file:
+
+.. code-block:: text
+
+  input:
+    diffdates: !include_from global_variables.yml::global.dates.GRAVITY_DIFFDATES
+
+This is an advantage if the dates in the global config is used also for other jobs. In this case the included file looks like this:
+
+.. code-block:: yaml
+
+  # example global config file with dates
+  global:
+    dates:
+      GRAVITY_DIFFDATES:
+      - - 2020-07-01
+        - 2018-01-01
+
+
 Station coordinates
 -------------------
 
@@ -39,11 +63,13 @@ The output files
 
 There will be two types of output file from grav_subs_points.
 
-- one column text files of modelled gravity change/subsidence that can be used with GEN_DATA observations
+- one column text files of modelled gravity change/subsidence GEN_DATA files that can be used with ert GEN_OBS observations
   
 - x,y,z text file that can be used for visualisation.
 
-The ordering of points in these two files will be the same as given in the station coordinates file used as input.
+The ordering of points in these two files will be the same as given in the station coordinates file used as input. It can therefore be a good idea to order the benchmark stations in the station coordinates file in the order you would like to see them in e.g. line plots, for instance sorted by area.
+
+In some cases where the reservoir model covers several structures or fields it can be beneficial to split the modelling for different structures into several files. E.g. for testing in assisted history matching what effect it has if only observations for one of the structures is used as observations compared to both. To facilitate this usage the option to add a prefix to the GEN_DATA file to separate them, using the prefix_gendata option. There is also a possibility to use a different report step and extension than the default "_1.txt" by using the extension_gendata option.
   
 
   

--- a/docs/scripts/grav_subs_points.rst
+++ b/docs/scripts/grav_subs_points.rst
@@ -18,7 +18,7 @@ it is possible to include them from another yaml file:
   input:
     diffdates: !include_from global_variables.yml::global.dates.GRAVITY_DIFFDATES
 
-This is an advantage if the dates in the global config is used also for other jobs. In this case the included file looks like this:
+This is an advantage if the dates in the global config is used also for other jobs. In this example the included file looks like this:
 
 .. code-block:: yaml
 
@@ -63,7 +63,7 @@ The output files
 
 There will be two types of output file from grav_subs_points.
 
-- one column text files of modelled gravity change/subsidence GEN_DATA files that can be used with ert GEN_OBS observations
+- one column text files of modelled gravity change/subsidence GEN_DATA files that can be used with ert GENERAL_OBSERVATION
   
 - x,y,z text file that can be used for visualisation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "ert",
     "ert>=10.2.0b13",
     "fmu-tools",
+    "grid3d_maps",
     "matplotlib",
     "numpy<2",
     "opm>=2023.04",

--- a/src/subscript/config_jobs/GRAV_SUBS_MAPS
+++ b/src/subscript/config_jobs/GRAV_SUBS_MAPS
@@ -1,10 +1,9 @@
 EXECUTABLE  grav_subs_maps
 
 DEFAULT  <OUTPUT_DIR> "./"
-DEFAULT  <ROOT_PATH> "./"
 
-ARGLIST  "--configfile" <GRAVMAPS_CONFIG> "--root-path" <ROOT_PATH> "--outputdir" <OUTPUT_DIR> <UNRST_FILE> 
+ARGLIST  "--configfile" <GRAVMAPS_CONFIG> "--outputdir" <OUTPUT_DIR> <UNRST_FILE> 
 
 MIN_ARG  2
-MAX_ARG  4
+MAX_ARG  3
 ARG_TYPE 0 STRING

--- a/src/subscript/config_jobs/GRAV_SUBS_POINTS
+++ b/src/subscript/config_jobs/GRAV_SUBS_POINTS
@@ -1,12 +1,13 @@
 EXECUTABLE  grav_subs_points
 
 DEFAULT  <OUTPUT_DIR> "./"
-DEFAULT  <ROOT_PATH> "./"
+
 DEFAULT  <PREFIX_GENDATA> ""
 DEFAULT  <EXTENSION_GENDATA> "_1.txt"
 
-ARGLIST  "--configfile" <GRAVPOINTS_CONFIG> "--root-path" <ROOT_PATH> "--outputdir" <OUTPUT_DIR> "--prefix_gendata" <PREFIX_GENDATA> "--extension_gendata" <EXTENSION_GENDATA> <UNRST_FILE> 
+ARGLIST  "--configfile" <GRAVPOINTS_CONFIG> "--outputdir" <OUTPUT_DIR> "--prefix_gendata" <PREFIX_GENDATA> "--extension_gendata" <EXTENSION_GENDATA> <UNRST_FILE> 
 
 MIN_ARG  2
-MAX_ARG  6
+MAX_ARG  5
+
 ARG_TYPE 0 STRING

--- a/src/subscript/grav_subs_points/grav_subs_points.py
+++ b/src/subscript/grav_subs_points/grav_subs_points.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 import yaml
+from grid3d_maps.avghc._loader import FMUYamlSafeLoader
 from pydantic import BaseModel, Field, FilePath, field_validator
 from resdata.gravimetry import ResdataGrav, ResdataSubsidence
 from resdata.grid import Grid
@@ -68,7 +69,7 @@ EXAMPLES = """
 
   FORWARD_MODEL GRAV_SUBS_POINTS(<UNRST_FILE=<ECLBASE>.UNRST, <GRAVPOINTS_CONFIG>=grav_subs_points.yml)
   FORWARD_MODEL GRAV_SUBS_POINTS(<UNRST_FILE=<ECLBASE>.UNRST, <GRAVPOINTS_CONFIG>=<CONFIG_PATH>/../input/config/grav_subs_points.yml, <OUTPUT_DIR>=share/results/points)
-  FORWARD_MODEL GRAV_SUBS_POINTS(<UNRST_FILE=<ECLBASE>.UNRST, <GRAVPOINTS_CONFIG>=grav_subs_points.yml, <ROOT_PATH>=<CONFIG_PATH>/../../gravity/input, <OUTPUT_DIR>=share/results/points)
+
   FORWARD_MODEL GRAV_SUBS_POINTS(<UNRST_FILE=<ECLBASE>.UNRST, <GRAVPOINTS_CONFIG>=grav_subs_points.yml, <EXTENSION_GENDATA>="_10.txt")
   FORWARD_MODEL GRAV_SUBS_POINTS(<UNRST_FILE=<ECLBASE>.UNRST, <GRAVPOINTS_CONFIG>=grav_subs_points.yml, <PREFIX_GENDATA>="fieldA_")
 
@@ -80,8 +81,6 @@ If not specified OUTPUT_DIR will be defaulted to "./".
 the output files of type GEN_DATA. The prefix can be used to separate datasets for
 different structures/fields within the dataset and is defaulted to an empty string,
 i.e. no prefix. The extension should include the report step number, and is defaulted to "_1.txt"
-``ROOT_PATH`` is the root path assumed for any relative paths in the yaml config file.
-This is optional and defaulted to "./".
 
 The directory to export point files to must exist.
 """  # noqa
@@ -139,13 +138,6 @@ def get_parser() -> argparse.ArgumentParser:
         required=True,
     )
     parser.add_argument(
-        "-r",
-        "--root-path",
-        type=str,
-        default="./",
-        help=("Root path assumed for relative paths" " in config file."),
-    )
-    parser.add_argument(
         "-o",
         "--outputdir",
         type=str,
@@ -185,7 +177,9 @@ def main() -> None:
     # parse the config file
     if not Path(args.configfile).exists():
         sys.exit("No such file:" + args.configfile)
-    config = yaml.safe_load(Path(args.configfile).read_text(encoding="utf8"))
+
+    with open(Path(args.configfile), "r", encoding="utf8") as stream:
+        config = yaml.load(stream, Loader=FMUYamlSafeLoader)
 
     if not Path(args.outputdir).exists():
         sys.exit("Output folder does not exist:" + args.outputdir)
@@ -195,45 +189,10 @@ def main() -> None:
     main_gravpoints(
         args.UNRSTfile,
         config,
-        Path(args.root_path),
         Path(args.outputdir),
         args.prefix_gendata,
         args.extension_gendata,
     )
-
-
-def prepend_root_path_to_relative_files(
-    cfg: Dict[str, Any], root_path: Path
-) -> Dict[str, Any]:
-    """Prepend root_path to relative files found paths in a configuration
-    dictionary.
-
-    Note: This function is before prior to validation of the configuration!
-
-    Will look for filename in the keys "grav" and "subs"
-
-    Args:
-        cfg: grav_subs_points configuration dictionary
-        root_path: A relative or absolute path to be prepended
-
-    Returns:
-        Modified configuration for grav_subs_points
-    """
-
-    stations = cfg.get("stations")
-
-    if stations is None:
-        return cfg
-
-    for key in ["grav", "subs"]:
-        if key in stations and isinstance(stations[key], dict):
-            for item in stations[key]:
-                if os.path.isabs(stations[key][item]):
-                    continue
-
-                stations[key][item] = str(root_path / Path(stations[key][item]))
-
-    return cfg
 
 
 def export_grav_points_xyz(act_stations, phase, diff_date, out_folder) -> None:
@@ -312,7 +271,6 @@ def export_subs_points_ert(
 def main_gravpoints(
     unrst_file: str,
     config: Dict[str, Any],
-    root_path: Optional[Path],
     output_folder: Optional[Path],
     pref_gendata: Optional[str],
     ext_gendata: Optional[str],
@@ -324,9 +282,6 @@ def main_gravpoints(
         resdata: Path to flow simulation UNRST file
         config: Configuration for modelling
     """
-
-    if root_path is not None:
-        config = prepend_root_path_to_relative_files(config, root_path)
 
     cfg = GravPointsConfig.model_validate(config).model_dump()
 

--- a/tests/test_grav_subs_maps.py
+++ b/tests/test_grav_subs_maps.py
@@ -4,35 +4,12 @@ import subprocess
 from pathlib import Path
 
 import pytest
-import yaml
 from pydantic import ValidationError
 
 from subscript.grav_subs_maps import grav_subs_maps
 from subscript.grav_subs_maps.grav_subs_maps import GravMapsConfig
 
 TESTDATA = Path(__file__).absolute().parent / "testdata_gravity"
-
-
-def test_prepend_root_path():
-    """Test that we need to prepend with root-path"""
-    cfg_file = TESTDATA / "grav_subs_maps.yml"
-
-    cfg = yaml.safe_load(cfg_file.read_text(encoding="utf8"))
-
-    with pytest.raises(ValidationError):
-        GravMapsConfig(**cfg)
-
-    cfg_with_rootpath = grav_subs_maps.prepend_root_path_to_relative_files(
-        cfg, TESTDATA
-    )
-    GravMapsConfig(**cfg_with_rootpath)
-
-    # When root-path is prepended (with an absolute part) it should not
-    # matter if we reapply:
-    cfg_with_double_rootpath = grav_subs_maps.prepend_root_path_to_relative_files(
-        cfg_with_rootpath, TESTDATA
-    )
-    GravMapsConfig(**cfg_with_double_rootpath)
 
 
 @pytest.fixture(name="res_data")
@@ -198,8 +175,7 @@ def test_ert_integration(res_data):
                 "RUNPATH <CONFIG_PATH>",
                 "",
                 "FORWARD_MODEL GRAV_SUBS_MAPS(<UNRST_FILE>=<ECLBASE>.UNRST, \
-                <GRAVMAPS_CONFIG>=grav_subs_maps.yml, <OUTPUT_DIR>=./, \
-                <ROOT_PATH>=./)",
+                <GRAVMAPS_CONFIG>=grav_subs_maps.yml, <OUTPUT_DIR>=./)",
             ]
         ),
         encoding="utf8",

--- a/tests/test_grav_subs_points.py
+++ b/tests/test_grav_subs_points.py
@@ -4,32 +4,12 @@ import subprocess
 from pathlib import Path
 
 import pytest
-import yaml
 from pydantic import ValidationError
 
 from subscript.grav_subs_points import grav_subs_points
 from subscript.grav_subs_points.grav_subs_points import GravPointsConfig
 
 TESTDATA = Path(__file__).absolute().parent / "testdata_gravity"
-
-
-def test_prepend_root_path():
-    """Test that we need to prepend with root-path"""
-    cfg_file = TESTDATA / "grav_subs_points.yml"
-
-    cfg = yaml.safe_load(cfg_file.read_text(encoding="utf8"))
-
-    cfg_with_rootpath = grav_subs_points.prepend_root_path_to_relative_files(
-        cfg, TESTDATA
-    )
-    GravPointsConfig(**cfg_with_rootpath)
-
-    # When root-path is prepended (with an absolute part) it should not
-    # matter if we reapply:
-    cfg_with_double_rootpath = grav_subs_points.prepend_root_path_to_relative_files(
-        cfg_with_rootpath, TESTDATA
-    )
-    GravPointsConfig(**cfg_with_double_rootpath)
 
 
 @pytest.fixture(name="res_data")
@@ -192,7 +172,6 @@ def test_unrst_error(dictupdates, expected_error):
             grav_subs_points.main_gravpoints(
                 unrst_file=test_resfile,
                 config=cfg,
-                root_path="./",
                 output_folder="./",
                 pref_gendata="",
                 ext_gendata="_1.txt",

--- a/tests/testdata_gravity/global_variables.yml
+++ b/tests/testdata_gravity/global_variables.yml
@@ -1,0 +1,6 @@
+# example configuration file with dates
+global:
+  dates:
+    GRAVITY_DIFFDATES:
+    - - 2020-07-01
+      - 2018-01-01

--- a/tests/testdata_gravity/grav_subs_maps.yml
+++ b/tests/testdata_gravity/grav_subs_maps.yml
@@ -1,12 +1,11 @@
 # Configuration file for use with grav_subs_maps.py
 
 input:
-  diffdates:
-    - [2020-07-01, 2018-01-01]
+  diffdates: !include_from global_variables.yml::global.dates.GRAVITY_DIFFDATES
   seabed_map: seabed.gri 
 
 calculations:
   poisson_ratio: 0.45
   coarsening: 8        
   phases: ["gas", "oil","water", "total"]
-
+  

--- a/tests/testdata_gravity/grav_subs_points.yml
+++ b/tests/testdata_gravity/grav_subs_points.yml
@@ -1,8 +1,7 @@
 # Configuration file for use with grav_subs_points.py
 
 input:
-  diffdates:
-    - [2020-07-01, 2018-01-01]
+  diffdates: !include_from global_variables.yml::global.dates.GRAVITY_DIFFDATES
     
 stations:
   grav:
@@ -13,4 +12,4 @@ stations:
 calculations:
   poisson_ratio: 0.45
   phases: ["gas", "oil","water", "total"]
-
+  


### PR DESCRIPTION
Solves #736 and #728

- Removing the option to specify root for relative paths
- Adding option to specify dates in yaml config by including it from a another global config yaml file.

The include_from option is using the FMUYamlSafeLoader in grid3d_maps