### PR TITLE
change default extension from _1.txt to .txt in src tests and docs

### DIFF
--- a/docs/scripts/grav_subs_points.rst
+++ b/docs/scripts/grav_subs_points.rst
@@ -69,7 +69,7 @@ There will be two types of output file from grav_subs_points.
 
 The ordering of points in these two files will be the same as given in the station coordinates file used as input. It can therefore be a good idea to order the benchmark stations in the station coordinates file in the order you would like to see them in e.g. line plots, for instance sorted by area.
 
-In some cases where the reservoir model covers several structures or fields it can be beneficial to split the modelling for different structures into several files. E.g. for testing in assisted history matching what effect it has if only observations for one of the structures is used as observations compared to both. To facilitate this usage the option to add a prefix to the GEN_DATA file to separate them, using the prefix_gendata option. There is also a possibility to use a different report step and extension than the default "_1.txt" by using the extension_gendata option.
+In some cases where the reservoir model covers several structures or fields it can be beneficial to split the modelling for different structures into several files. E.g. for testing in assisted history matching what effect it has if only observations for one of the structures is used as observations compared to both. To facilitate this usage the option to add a prefix to the GEN_DATA file to separate them, using the prefix_gendata option. There is also a possibility to use a different report step and extension than the default ".txt" by using the extension_gendata option. The default is now without any report step, since this is now longer needed in ert. But if defining a report step is needed, an extension like e.g. "_10.txt" could be given. 
   
 
   

--- a/src/subscript/config_jobs/GRAV_SUBS_POINTS
+++ b/src/subscript/config_jobs/GRAV_SUBS_POINTS
@@ -3,7 +3,7 @@ EXECUTABLE  grav_subs_points
 DEFAULT  <OUTPUT_DIR> "./"
 
 DEFAULT  <PREFIX_GENDATA> ""
-DEFAULT  <EXTENSION_GENDATA> "_1.txt"
+DEFAULT  <EXTENSION_GENDATA> ".txt"
 
 ARGLIST  "--configfile" <GRAVPOINTS_CONFIG> "--outputdir" <OUTPUT_DIR> "--prefix_gendata" <PREFIX_GENDATA> "--extension_gendata" <EXTENSION_GENDATA> <UNRST_FILE> 
 

--- a/src/subscript/grav_subs_points/grav_subs_points.py
+++ b/src/subscript/grav_subs_points/grav_subs_points.py
@@ -25,7 +25,7 @@ logger = subscript.getLogger(__name__)
 DUMMY_YOUNGS = 10
 
 PREFIX_POINTS = "all"  # calculation is cumulative over all zones
-EXTENSION_POINTS = ".txt"  # extension for points in roxar points format
+EXTENSION_POINTS = ".poi"  # extension for points in roxar points format
 
 DESCRIPTION = """
 Modelling gravity change and subsidence based on flow simulation
@@ -80,7 +80,8 @@ If not specified OUTPUT_DIR will be defaulted to "./".
 ``PREFIX_GENDATA`` and ``EXTENSION_GENDATA`` is the file prefix and extension used for
 the output files of type GEN_DATA. The prefix can be used to separate datasets for
 different structures/fields within the dataset and is defaulted to an empty string,
-i.e. no prefix. The extension should include the report step number, and is defaulted to "_1.txt"
+i.e. no prefix. The extension could include the report step number by defining e.g. "_10.txt",
+but is defaulted without it a report step number, to only ".txt"
 
 The directory to export point files to must exist.
 """  # noqa
@@ -157,7 +158,7 @@ def get_parser() -> argparse.ArgumentParser:
             "File extension used for output files for GEN_DATA,"
             "including report step number"
         ),
-        default="_1.txt",
+        default=".txt",
     )
     parser.add_argument(
         "--version",

--- a/tests/test_grav_subs_points.py
+++ b/tests/test_grav_subs_points.py
@@ -174,7 +174,7 @@ def test_unrst_error(dictupdates, expected_error):
                 config=cfg,
                 output_folder="./",
                 pref_gendata="",
-                ext_gendata="_1.txt",
+                ext_gendata=".txt",
             )
         assert expected_error in str(system_error.value.code)
 
@@ -200,13 +200,13 @@ def test_main(res_data, mocker):
     )
     grav_subs_points.main()
 
-    assert Path("all--delta_gravity_total--20200701_20180101.txt").exists()
-    assert Path("all--delta_gravity_gas--20200701_20180101.txt").exists()
-    assert Path("all--delta_gravity_oil--20200701_20180101.txt").exists()
-    assert Path("all--delta_gravity_water--20200701_20180101.txt").exists()
-    assert Path("all--subsidence--20200701_20180101.txt").exists()
-    assert Path("gravity_20200701_20180101_1.txt").exists()
-    assert Path("subsidence_20200701_20180101_1.txt").exists()
+    assert Path("all--delta_gravity_total--20200701_20180101.poi").exists()
+    assert Path("all--delta_gravity_gas--20200701_20180101.poi").exists()
+    assert Path("all--delta_gravity_oil--20200701_20180101.poi").exists()
+    assert Path("all--delta_gravity_water--20200701_20180101.poi").exists()
+    assert Path("all--subsidence--20200701_20180101.poi").exists()
+    assert Path("gravity_20200701_20180101.txt").exists()
+    assert Path("subsidence_20200701_20180101.txt").exists()
 
 
 @pytest.mark.integration
@@ -229,7 +229,7 @@ def test_ert_integration(res_data):
         encoding="utf8",
     )
     subprocess.run(["ert", "test_run", "test.ert"], check=True)
-    assert Path("subsidence_20200701_20180101_1.txt").is_file()
+    assert Path("subsidence_20200701_20180101.txt").is_file()
 
     # Test also with non default arguments for filename and directory
     Path("test.ert").write_text(


### PR DESCRIPTION
Since a report step is no longer needed for GEN_DATA in ert, the default extension for export to GEN_DATA file has been changed from "_1.txt" to ".txt". Documentation is also updated with this.  Solves #741 