### PR TITLE
add rporv workaround

### DIFF
--- a/src/subscript/grav_subs_maps/grav_subs_maps.py
+++ b/src/subscript/grav_subs_maps/grav_subs_maps.py
@@ -215,7 +215,16 @@ def main_gravmaps(
             if singledate not in added_dates:
                 if singledate in restart_index:
                     rsb = rest.restartView(restart_index[singledate])
-                    grav.add_survey_RFIP(singledate, rsb)
+                    if rest.has_kw("RFIPGAS"):
+                        grav.add_survey_RFIP(singledate, rsb)
+                    else:
+                        logger.info(
+                            "RFIPGAS missing in restart file.  "
+                            "Cannot use RFIP in gravity calculations.  "
+                            "Will try to use RPORV method instead"
+                        )
+                        grav.add_survey_RPORV(singledate, rsb)
+
                     subsidence.add_survey_PRESSURE(singledate, rsb)
                     added_dates.append(singledate)
                 else:

--- a/src/subscript/grav_subs_points/grav_subs_points.py
+++ b/src/subscript/grav_subs_points/grav_subs_points.py
@@ -325,7 +325,16 @@ def main_gravpoints(
             if singledate not in added_dates:
                 if singledate in restart_index:
                     rsb = rest.restartView(restart_index[singledate])
-                    grav.add_survey_RFIP(singledate, rsb)
+                    if rest.has_kw("RFIPGAS"):
+                        grav.add_survey_RFIP(singledate, rsb)
+                    else:
+                        logger.info(
+                            "RFIPGAS missing in restart file.  "
+                            "Cannot use RFIP in gravity calculations.  "
+                            "Will try to use RPORV method instead"
+                        )
+                        grav.add_survey_RPORV(singledate, rsb)
+
                     subsidence.add_survey_PRESSURE(singledate, rsb)
                     added_dates.append(singledate)
                 else:


### PR DESCRIPTION
When RFIP for each phase is missing in the UNRST file, the preferred resdata gravimetry method add_survey_RFIP is failing. A workaround is to use the add_survey_RPORV method instead, which calculates RFIP from RPORV and phase densitities. This is currently needed when using OPM FLOW as simulator, since it does not output RFIP to the UNRST file.  Solves #740 

Adding this workaround allows for implementation of the gravity modelling in Drogon. 

