### PR TITLE
Use memoryconservative mode for WF CSV_MERGE

### DIFF
--- a/src/subscript/csv_merge/csv_merge.py
+++ b/src/subscript/csv_merge/csv_merge.py
@@ -68,7 +68,9 @@ class CsvMerge(ErtScript):
         args = parser.parse_args(args)
         logger.setLevel(logging.INFO)
         globbedfiles = glob_patterns(args.csvfiles)
-        csv_merge_main(csvfiles=globbedfiles, output=args.output)
+        csv_merge_main(
+            csvfiles=globbedfiles, output=args.output, memoryconservative=True
+        )
 
 
 def get_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
When run as a workflow job/ert plugin this has been observed through logging to fail due to lack of memory.

When run as a workflow job, it is probable that there is one CSV for every realization that is to be loaded, thus the memory conservative option probably makes sense to have on by default.

Keeping the faster option as default for usages as a forward model step.