### PR TITLE
Fixed initialization to make the generated script work more generally

### DIFF
--- a/src/subscript/field_statistics/field_statistics.py
+++ b/src/subscript/field_statistics/field_statistics.py
@@ -1630,10 +1630,12 @@ def main():
             zone_list = list(zone_code_names.values())
 
         key = "continuous_property_param_per_zone"
+        cont_prop_dict = None
         if key in geogrid_fields_dict:
             cont_prop_dict = geogrid_fields_dict[key]
 
         key = "discrete_property_param_per_zone"
+        discrete_prop_dict = None
         if key in geogrid_fields_dict:
             discrete_prop_dict = geogrid_fields_dict[key]
 


### PR DESCRIPTION
The field statistics script can generate a python script to be used as a job in RMS to load the mean and std dev and probability field parameters calculated by the field statistics script. Fixed  missing initialization to make the script more flexible and avoid errors.