### PR TITLE
Deduce nonzero returncode from eclrun std output

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import subprocess
 import time
 from os import getcwd
@@ -29,11 +30,21 @@ def run_simulator(simulator, data_file_path):
         [simulator] + simulator_option + [data_file_path],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        check=False,
     )
+    if (
+        "eclrun" in simulator
+        and _error_count_from_ecl_stdout(
+            result.stdout.decode() + result.stderr.decode()
+        )
+        > 0
+    ):
+        # eclrun returns returncode 0 matter what.
+        result.returncode = 1
 
     if (
         result.returncode != 0
-        and "eclipse" in simulator
+        and "ecl" in simulator
         and "LICENSE FAILURE" in result.stdout.decode() + result.stderr.decode()
     ):
         print("Eclipse failed due to license server issues. Retrying in 30 seconds.")
@@ -48,3 +59,12 @@ def run_simulator(simulator, data_file_path):
         print(result.stdout.decode())
         print(result.stderr.decode())
         raise AssertionError(f"reservoir simulator failed in {getcwd()}")
+
+
+def _error_count_from_ecl_stdout(stdouterr: str):
+    error_count = 0
+    for line in stdouterr.splitlines():
+        if line.startswith(" Errors"):
+            with contextlib.suppress(ValueError):
+                error_count = int(line.split("Errors")[1].strip())
+    return error_count


### PR DESCRIPTION
runeclipse from subscript was used for this earlier, and this had code to parse the stdout/stderr files for Error counts.