### PR TITLE
Make sourcing of eclrun non-flaky

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -30,6 +30,12 @@ get_os_arch () {
 
 start_tests () {
     os_arch="$(get_os_arch)"
+
+    SHELLOPTS_BEFORE=$(set +o)
+    set +e
+    # (this script becomes flaky if set -e is active)
     source /prog/res/ecl/script/eclrun.bash
+    eval "$SHELLOPTS_BEFORE"
+
     pytest -n auto --flow-simulator="/project/res/$os_arch/bin/flowdaily" --eclipse-simulator="eclrun"
 }


### PR DESCRIPTION
If there is a simple bash test that fails in the sourced file, the sourcing will fail when it is run in an environment where 'set -e' is set. Ensure this is temporarily unset