### PR TITLE
Fix some bugs in fmu_copy_revision

### DIFF
--- a/src/subscript/fmu_copy_revision/fmu_copy_revision.py
+++ b/src/subscript/fmu_copy_revision/fmu_copy_revision.py
@@ -280,7 +280,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--profile",
         dest="profile",
         type=int,
-        help="profile for copy profile to use, default is 4",
+        help=f"profile for copy profile to use, default is {DEFAULT_PROFILE}",
     )
     parser.add_argument(
         "--threads",
@@ -676,7 +676,7 @@ def main(args=None) -> None:
         runner.do_rsyncing()
     else:
         print("Command line mode!")
-        runner.profile = int(runner.args.profile)
+        runner.profile = int(runner.args.profile or DEFAULT_PROFILE)
         runner.source = runner.args.source
         runner.batch = True
 

--- a/src/subscript/fmu_copy_revision/fmu_copy_revision.py
+++ b/src/subscript/fmu_copy_revision/fmu_copy_revision.py
@@ -401,6 +401,15 @@ class CopyFMU:
         logger.info("Default target is %s", self.default_target.resolve())
 
     def construct_target(self, proposal):
+        def _clean_folder(folder):
+            """Remove all files and subdirectories inside the folder,
+            while keeping the folder itself intact, unlike shutil.rmtree."""
+            for item in Path(folder).iterdir():
+                if item.is_dir():
+                    shutil.rmtree(item)
+                else:
+                    item.unlink()
+
         """Final target as abs path string, and evaluate cleanup or merge."""
         target = Path(proposal)
         self.target = str(target.absolute())
@@ -413,7 +422,8 @@ class CopyFMU:
             print(f"Target is already present: <{self.target}>")
             if self.args.cleanup:
                 print("Doing cleanup of current target...")
-                shutil.rmtree(self.target)
+                _clean_folder(self.target)
+
             elif self.args.merge:
                 print("Doing merge copy of current target...")
             else:

--- a/tests/test_fmu_copy_revision.py
+++ b/tests/test_fmu_copy_revision.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 import subscript.fmu_copy_revision.fmu_copy_revision as fcr
+from subscript.fmu_copy_revision.fmu_copy_revision import DEFAULT_PROFILE
 
 SCRIPTNAME = "fmu_copy_revision"
 
@@ -263,6 +264,15 @@ def test_missing_directory_permissions(tmp_path, rmsinputperm, profile):
 def test_integration():
     """Test that the endpoint is installed."""
     assert subprocess.check_output([SCRIPTNAME, "-h"])
+
+
+def test_default_profile(datatree):
+    """Test command line mode"""
+    os.chdir(datatree)
+    result = subprocess.run(
+        ["fmu_copy_revision", "--source", datatree], check=True, stdout=subprocess.PIPE
+    )
+    assert f"Doing copy with profile {DEFAULT_PROFILE}" in result.stdout.decode()
 
 
 def test_choice_profile1(datatree):


### PR DESCRIPTION
- Closes #777
Default profile is not being set when user run in command line mode. 

- Closes #778 
Target directory is removed when using `shutil.rmtree` causing `Stale file handle` error message when target directory is set to current directory. I am not able to replicate the error in unit test (help is appreciated). Probably due to small test case. But it seems to work when tested on Drogon.




