### PR TITLE
Drop python 3.8 and add 3.12

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-latest]
     env:
       OS: ${{ matrix.os }}
-      PYTHON: '3.8'
+      PYTHON: '3.12'
 
     steps:
 
@@ -27,7 +27,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.12
 
     - name: Install OPM-flow and ResInsight (for testing)
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/subscript.yml
+++ b/.github/workflows/subscript.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
 
@@ -91,7 +91,7 @@ jobs:
         run: sphinx-build -b html docs build/docs/html
 
       - name: Update GitHub pages
-        if: github.repository_owner == 'equinor' && github.ref == 'refs/heads/main' && matrix.python-version == '3.8'
+        if: github.repository_owner == 'equinor' && github.ref == 'refs/heads/main' && matrix.python-version == '3.12'
         run: |
           cp -R ./build/docs/html ../html
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![subscript](https://github.com/equinor/subscript/actions/workflows/subscript.yml/badge.svg)](https://github.com/equinor/subscript/actions/workflows/subscript.yml)
 [![codecov](https://codecov.io/gh/equinor/subscript/branch/master/graph/badge.svg)](https://codecov.io/gh/equinor/subscript)
-![Python Version](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10%20|%203.11-blue.svg)
+![Python Version](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12-blue.svg)
 [![License: GPL v3](https://img.shields.io/github/license/equinor/subscript)](https://www.gnu.org/licenses/gpl-3.0)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ tests = [
 ]
 docs = [
     "autoapi",
-    "sphinx",
+    "sphinx<8.2.0",
     "sphinx-argparse",
     "sphinx-autodoc-typehints<2.4",
     "sphinx-copybutton",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Utilities",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Natural Language :: English",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
@@ -63,7 +63,7 @@ tests = [
     "pytest-cov",
     "pytest-mock",
     "pytest-xdist",
-    "PyQt5-sip<12.16.0; python_version == '3.8'",
+    "PyQt5-sip",
     "rstcheck",
     "rstcheck-core",
     "ruff",
@@ -73,7 +73,7 @@ tests = [
 ]
 docs = [
     "autoapi",
-    "sphinx<8.2.0",
+    "sphinx",
     "sphinx-argparse",
     "sphinx-autodoc-typehints<2.4",
     "sphinx-copybutton",


### PR DESCRIPTION
Close #780 
- Drop support for python 3.8
- Add support for python 3.12
- Use python 3.12 as default in Github action