### PR TITLE
Fix issue with Flow test

### DIFF
--- a/.github/workflows/subscript.yml
+++ b/.github/workflows/subscript.yml
@@ -63,6 +63,11 @@ jobs:
           ResInsight --console --help | grep "ResInsight v. 2020.10" \
             && pip install rips==2020.10.0.2 || true
 
+      - name: Log OPM-Flow and ResInsight version
+        run: |
+          flow --version
+          ResInsight --console --version
+
       - name: List all installed packages
         run: pip freeze
 

--- a/.github/workflows/subscript.yml
+++ b/.github/workflows/subscript.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![subscript](https://github.com/equinor/subscript/actions/workflows/subscript.yml/badge.svg)](https://github.com/equinor/subscript/actions/workflows/subscript.yml)
 [![codecov](https://codecov.io/gh/equinor/subscript/branch/master/graph/badge.svg)](https://codecov.io/gh/equinor/subscript)
-![Python Version](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12-blue.svg)
+![Python Version](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue.svg)
 [![License: GPL v3](https://img.shields.io/github/license/equinor/subscript)](https://www.gnu.org/licenses/gpl-3.0)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ write_to = "src/subscript/version.py"
 name = "subscript"
 description = "Equinor's collection of subsurface reservoir modelling scripts"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = { file = "LICENSE" }
 authors = [
     { name = "Equinor", email = "rnyb@equinor.com" },
@@ -27,8 +27,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Utilities",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Natural Language :: English",

--- a/tests/test_check_swatinit_simulators.py
+++ b/tests/test_check_swatinit_simulators.py
@@ -795,16 +795,6 @@ def test_no_unrst(tmp_path, mocker, flow_simulator):
         main()
 
 
-def test_no_rptrst(tmp_path, mocker, flow_simulator):
-    """Test what happens when RPTRST is not included, no UNRST"""
-    os.chdir(tmp_path)
-    model = PillarModel(rptrst="")
-    run_reservoir_simulator(flow_simulator, model, perform_qc=False)
-    mocker.patch("sys.argv", ["check_swatinit", "FOO.DATA"])
-    with pytest.raises(SystemExit, match="UNRST"):
-        main()
-
-
 def test_rptrst_basic_1(simulator, tmp_path, mocker):
     """Test what happens when RPTRST is BASIC=1"""
     os.chdir(tmp_path)


### PR DESCRIPTION
This PR has three different purposes:
1. Log ResInsight and OPM Flow version
2. Remove `test_no_rptrst` from `test_check_swatinit_simulators.py`. It's supposed to check that UNRST file is not generated when data deck is missing RPTRST keyword. From OPM Flow 2025.10, UNRST file be automatically created for initial time unless user turn it off. https://github.com/OPM/opm-simulators/pull/6119
3. Drop support for Python 3.9 and 3.10 due to dependency to res2df