### PR TITLE
`prtvol2csv` - Added warning for not initial report

### DIFF
--- a/tests/test_prtvol2csv.py
+++ b/tests/test_prtvol2csv.py
@@ -569,6 +569,36 @@ def test_inactive_fipnum(tmp_path, mocker):
     assert dframe.loc[dframe["FIPNUM"].idxmax(), "HCPV_TOTAL"] != 0
 
 
+def test_warning_not_initial(tmp_path, mocker):
+    """Test that the warning about not inital volume report is triggered"""
+
+    # with Eclipse PRT file, BALANCE report only
+    prtfile_ecl = TEST_PRT_DATADIR / "DROGON_NO_INITIAL_BALANCE.PRT"
+
+    # with OPM Flow PRT file, BALANCE, BALZON (for FIPZON), RESERVOIR VOLUME reports
+    prtfile_flow = TEST_PRT_DATADIR / "DROGON_NO_INITIAL_BALANCE_FLOW.PRT"
+
+    os.chdir(tmp_path)
+
+    with pytest.warns(UserWarning, match="not at initial time") as warnings_record:
+        mocker.patch(
+            "sys.argv",
+            ["prtvol2csv", "--debug", "--dir", ".", str(prtfile_ecl)],
+        )
+        prtvol2csv.main()
+
+        mocker.patch(
+            "sys.argv",
+            ["prtvol2csv", "--debug", "--dir", ".", str(prtfile_flow)],
+        )
+        prtvol2csv.main()
+
+        # Extra output for debugging, if test fails
+        for i, warning in enumerate(warnings_record):
+            print(f"{i + 1} Recorded warnings: {warning.message}")
+    assert len(warnings_record) == 2
+
+
 def test_find_prtfile(tmp_path):
     """Test location service for PRT files"""
     os.chdir(tmp_path)

--- a/tests/testdata_prtvol2csv/0readme.txt
+++ b/tests/testdata_prtvol2csv/0readme.txt
@@ -8,5 +8,10 @@ and in addition FIPRESV for reservoir volumes.
 Both PRT files have reservoir volumes.
 One additional FIP vector in the second file, named FIPZON.
 
-DROGON_FIPNUM.PRT       - Eclipse version 2022.2, FIP=2 (FIPNUM only)
+DROGON_FIPNUM.PRT       - Eclipse version 2022.2, FIP=2 (FIPNUM only, 4 reports)
 DROGON_FIPZON.PRT       - Eclipse version 2022.2, FIP=3 (all FIP-vectors)
+DROGON_INACTIVE_FIPNUM.PRT -  with FIPNUM 5 as inactive
+DROGON_NO_INITIAL_BALANCE.PRT       - Eclipse version 2025.1, FIP=2 (FIPNUM only, no initial BALANCE report)
+                                    first BALANCE report after 6 months, no RESERVOIR VOLUMES reports
+DROGON_NO_INITIAL_BALANCE_FLOW.PRT  - OPM Flow version 2025.10-pre, no initial BALANCE report
+                                    FIP=3 (FIP*, all FIP vectors, one RESERVOIR VOLUMES report)

--- a/tests/testdata_prtvol2csv/DROGON_NO_INITIAL_BALANCE.PRT
+++ b/tests/testdata_prtvol2csv/DROGON_NO_INITIAL_BALANCE.PRT
@@ -1,0 +1,4189 @@
+
+
+
+ $$$$$         $     $                             $    $$$    $$$ 
+ $             $                                  $$   $   $  $   $
+ $       $$$   $     $   $$$$    $$$     $$$       $   $   $  $   $
+ $$$$   $   $  $     $   $   $  $       $   $      $   $   $  $   $
+ $      $      $     $   $   $   $$$    $$$$       $   $   $  $   $
+ $      $   $  $     $   $   $      $   $          $   $   $  $   $
+ $$$$$   $$$    $$   $   $$$$    $$$     $$$      $$$   $$$    $$$ 
+                         $                                         
+                         $                                         
+
+
+
+                       $$$$$         $     $                             $    $$$    $$$ 
+                       $             $                                  $$   $   $  $   $
+                       $       $$$   $     $   $$$$    $$$     $$$       $   $   $  $   $
+                       $$$$   $   $  $     $   $   $  $       $   $      $   $   $  $   $
+                       $      $      $     $   $   $   $$$    $$$$       $   $   $  $   $
+                       $      $   $  $     $   $   $      $   $          $   $   $  $   $
+                       $$$$$   $$$    $$   $   $$$$    $$$     $$$      $$$   $$$    $$$ 
+                                               $                                         
+                                               $                                         
+
+
+
+                                             $$$$$         $     $                             $    $$$    $$$ 
+                                             $             $                                  $$   $   $  $   $
+                                             $       $$$   $     $   $$$$    $$$     $$$       $   $   $  $   $
+                                             $$$$   $   $  $     $   $   $  $       $   $      $   $   $  $   $
+                                             $      $      $     $   $   $   $$$    $$$$       $   $   $  $   $
+                                             $      $   $  $     $   $   $      $   $          $   $   $  $   $
+                                             $$$$$   $$$    $$   $   $$$$    $$$     $$$      $$$   $$$    $$$ 
+                                                                     $                                         
+                                                                     $                                         
+
+
+
+                                                                   $$$$$         $     $                             $    $$$    $$$ 
+                                                                   $             $                                  $$   $   $  $   $
+                                                                   $       $$$   $     $   $$$$    $$$     $$$       $   $   $  $   $
+                                                                   $$$$   $   $  $     $   $   $  $       $   $      $   $   $  $   $
+                                                                   $      $      $     $   $   $   $$$    $$$$       $   $   $  $   $
+                                                                   $      $   $  $     $   $   $      $   $          $   $   $  $   $
+                                                                   $$$$$   $$$    $$   $   $$$$    $$$     $$$      $$$   $$$    $$$ 
+                                                                                           $                                         
+                                                                                           $                                         
+
+Proprietary Notice
+This application contains the confidential and proprietary trade secrets of SLB and may not be copied or stored in an
+information retrieval system, transferred, used, distributed, translated, or retransmitted in any form or by any means, electronic
+or mechanical, in whole or in part, without the express written permission of the copyright owner.
+
+Eclipse is a mark of SLB. Copyright (c) 1981-2025 SLB. All rights reserved.
+
+Version =  2025.1  
+Arch    =  Linux X86_64 (64 bit, LINRH8_IFX24GC13_OPT)
+
+Annex    | Modification date    | Update date          | Baseline     | Build       | Hash                 
+=====    | =================    | ===========          | ========     | =====       | ====                      
+Eclipse  | 06-MAY-2025 13:25:03 | 06-MAY-2025 13:20:06 | 2025.1       | 20250506.1  | 479afcfc17e-(branch: 2025.1)
+petlast  | 06-MAY-2025 13:25:03 | 06-MAY-2025 13:20:06 | 2025.1       | 20250506.1  | 479afcfc17e-(branch: 2025.1)
+system   | 06-MAY-2025 13:25:03 | 06-MAY-2025 13:20:06 | 2025.1       | 20250506.1  | 479afcfc17e-(branch: 2025.1)
+tpb      | 06-MAY-2025 13:25:03 | 06-MAY-2025 13:20:06 | 2025.1       | 20250506.1  | 479afcfc17e-(branch: 2025.1)
+utility  | 06-MAY-2025 13:25:03 | 06-MAY-2025 13:20:06 | 2025.1       | 20250506.1  | 479afcfc17e-(branch: 2025.1)
+ 
+
+1
+
+ ******** ECHO OF INPUT DATA FOR RUN DROGON_NO_INITIAL-99
+ RUN ON 28/05/2025 AT 09:06:19 VERSION 2025.1  
+
+ 0: --==============================================================================
+ 0: --		Synthetic reservoir simulation model Drogon (2020)
+ 0: --==============================================================================
+ 0: 
+ 0: -- The Drogon model - the successor of the Reek model
+ 0: -- Used in a FMU set up
+ 0: -- Grid input data generated from RMS project
+ 0: 
+ 0: 
+ 0: -- =============================================================================
+ 0: RUNSPEC
+ 0: -- =============================================================================
+ 0: 
+ 0: -- Simulation run title
+ 0: TITLE
+ 0:  Drogon synthetic reservoir model
+ 0: 
+ 0: -- Simulation run start
+ 0: START
+ 0:  1 JAN 2018 /
+ 0: 
+ 0: -- Fluid phases present
+ 0: OIL
+ 0: GAS
+ 0: WATER
+ 0: DISGAS
+ 0: VAPOIL
+ 0: 
+ 0: -- Measurement unit used
+ 0: METRIC
+ 0: 
+ 0: CPR
+ 0: /
+ 0: 
+ 0: -- Options for equilibration
+ 0: EQLOPTS
+ 0:  'THPRES'  /
+ 0: 
+ 0: -- Dimensions and options for tracers
+ 0: -- 2 water tracers
+ 0: TRACERS
+ 0: 
+ 0: -- Grid dimension
+ 0: INCLUDE
+
+ ******** START OF INCLUDED FILE ../include/runspec/drogon.dimens                                                                                                    
+
+ 1: -- Generated by RMS
+ 1: DIMENS
+ 1:   46  73  31 /
+
+ ******** END OF INCLUDED FILE 
+
+ 0: 
+ 0: -- Table dimensions
+ 0: INCLUDE
+
+ ******** START OF INCLUDED FILE ../include/runspec/drogon.tabdims                                                                                                   
+
+ 1: -- Generated by RMS
+ 1: TABDIMS
+ 1: -- NTSFUN  NTPVT  NSSFUN  NPPVT  NTFIP  NRPVT   ...
+ 1:     12      2      200     24     6      20    /
+
+ ******** END OF INCLUDED FILE 
+
+ 0: 
+ 0: -- Dimension of equilibration tables
+ 0: INCLUDE
+
+ ******** START OF INCLUDED FILE ../include/runspec/drogon.eqldims                                                                                                   
+
+ 1: -- Generated by RMS
+ 1: EQLDIMS
+ 1: -- NTEQUL
+ 1:     7 /
+
+ ******** END OF INCLUDED FILE 
+
+ 0: 
+ 0: -- Regions dimension data
+ 0: INCLUDE
+
+ ******** START OF INCLUDED FILE ../include/runspec/drogon.regdims                                                                                                   
+
+ 1: -- Generated by RMS
+ 1: REGDIMS
+ 1: -- NTFIP  NMFIPR
+ 1:     21      2 /
+
+ ******** END OF INCLUDED FILE 
+
+ 0: 
+ 0: -- x-,y-,z- and multnum regions
+ 0: INCLUDE
+
+ ******** START OF INCLUDED FILE ../include/runspec/drogon.gridopts                                                                                                  
+
+ 1: -- Generated by RMS
+ 1: GRIDOPTS
+ 1:  'YES'   21    /
+
+ ******** END OF INCLUDED FILE 
+
+ 0: 
+ 0: -- Dimensions for fault data
+ 0: FAULTDIM
+ 0:  500 /
+ 0: 
+ 0: -- Well dimension data
+ 0: -- nwmaxz: max wells in the model
+ 0: -- ncwmax: max connections per well
+ 0: -- ngmaxz: max groups in the model
+ 0: -- nwgmax: max wells in any one group
+ 0: WELLDIMS
+ 0: -- nwmaxz  ncwmax  ngmaxz  nwgmax
+ 0:    20       100     10       20 /
+ 0: 
+ 0: -- Dimensions for multi-segment wells
+ 0: -- nswlmx: max multi-segment wells in the model
+ 0: -- nsegmx: max segments per well
+ 0: -- nlbrmx: max branches per multi-segment well
+ 0: WSEGDIMS
+ 0: -- nswlmx  nsegmx  nlbrmx
+ 0:    3       150      100 /
+ 0: 
+ 0: -- VFP table dimensions
+ 0: -- 1. Max number of flow values per table
+ 0: -- 2. Max number of THP values per table
+ 0: -- 3. Max number of WFR values per table
+ 0: -- 4. Max number of GFR values per table
+ 0: -- 5. Max number of ALQ values per table
+ 0: -- 6. Max number of VFP tables
+ 0: VFPPDIMS
+ 0: 11 8 8 8 1 4 /
+ 0: 
+ 0: 
+ 0: -- Input and output files format
+ 0: UNIFIN
+ 0: UNIFOUT
+ 0: 
+ 0: 
+ 0: -- print and stop limits
+ 0: -- -----------print------------  -----------stop--------------------
+ 0: -- mes  com  war  prb  err  bug  mes  com   war     prb    err  bug
+ 0: MESSAGES
+ 0:    1*   1*   1*   1000 10   1*   1*    1*  1000000 7000    1    1   /
+ 0: 
+ 0: 
+ 0: -- =============================================================================
+ 0: GRID
+ 0: -- =============================================================================
+ 0: NOECHO
+
+ ******** START OF INCLUDED FILE ../include/grid/drogon.faults                                                                                                       
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/grid/drogon.multnum                                                                                                      
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/grid/drogon.multregt                                                                                                     
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/edit/drogon.trans                                                                                                        
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/props/drogon.sattab                                                                                                      
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/props/drogon.pvt                                                                                                         
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/regions/drogon.eqlnum                                                                                                    
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/regions/drogon.fipnum                                                                                                    
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/regions/drogon.fipzon                                                                                                    
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/regions/drogon.satnum                                                                                                    
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/regions/drogon.pvtnum                                                                                                    
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/solution/drogon.equil                                                                                                    
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/solution/drogon.rxvd                                                                                                     
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/solution/drogon.thpres                                                                                                   
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/summary/drogon.summary                                                                                                   
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/schedule/vfp/A-1.inc                                                                                                     
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/schedule/vfp/A-2.inc                                                                                                     
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/schedule/vfp/A-3.inc                                                                                                     
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/schedule/vfp/A-4.inc                                                                                                     
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** START OF INCLUDED FILE ../include/schedule/drogon_hist.sch                                                                                                 
+
+
+ ******** END OF INCLUDED FILE 
+
+
+ ******** END OF INPUT DATA FOR RUN DROGON_NO_INITIAL-99
+     1 READING RUNSPEC 
+     2 READING TITLE   
+     3 READING START   
+     4 READING OIL     
+     5 READING GAS     
+     6 READING WATER   
+     7 READING DISGAS  
+     8 READING VAPOIL  
+     9 READING METRIC  
+    10 READING CPR     
+    11 READING EQLOPTS 
+    12 READING TRACERS 
+    13 READING INCLUDE ../include/runspec/drogon.dimens                                                                                                    
+    14 READING DIMENS  
+               END OF INCLUDE FILE 
+    15 READING INCLUDE ../include/runspec/drogon.tabdims                                                                                                   
+    16 READING TABDIMS 
+               END OF INCLUDE FILE 
+    17 READING INCLUDE ../include/runspec/drogon.eqldims                                                                                                   
+    18 READING EQLDIMS 
+               END OF INCLUDE FILE 
+    19 READING INCLUDE ../include/runspec/drogon.regdims                                                                                                   
+    20 READING REGDIMS 
+               END OF INCLUDE FILE 
+    21 READING INCLUDE ../include/runspec/drogon.gridopts                                                                                                  
+    22 READING GRIDOPTS
+               END OF INCLUDE FILE 
+    23 READING FAULTDIM
+    24 READING WELLDIMS
+    25 READING WSEGDIMS
+    26 READING VFPPDIMS
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           CHECKING FOR LICENSES                                           
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           ECLIPSE SPECIAL OPTIONS CHECKED OUT:                            
+ @           multiseg                                                        
+    27 READING UNIFIN  
+    28 READING UNIFOUT 
+    29 READING MESSAGES
+    30 READING GRID    
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THE CPR LINEAR SOLVER HAS BEEN ACTIVATED                        
+ @           IN ADAPTIVE MODE.                                               
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           CHECKING FOR LICENSES                                           
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           ECLIPSE LICENSE CHECKED OUT                                     
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THE MEMORY REQUIRED TO PROCESS THE GRID SECTION IS              
+ @                68364 KBYTES                                               
+    31 READING NOECHO  
+    32 READING NEWTRAN 
+    33 READING GRIDFILE
+    34 READING INIT    
+    35 READING PINCH   
+    36 READING IMPORT  
+    37 READING MAPAXES 
+    38 READING SPECGRID
+    39 READING COORD   
+    40 READING ZCORN   
+    41 READING ACTNUM  
+    42 READING INCLUDE ../include/grid/drogon.faults                                                                                                       
+    43 READING FAULTS  
+               END OF INCLUDE FILE 
+    44 READING IMPORT  
+    45 READING PORO    
+    46 READING IMPORT  
+    47 READING PERMX   
+    48 READING PERMY   
+    49 READING PERMZ   
+    50 READING INCLUDE ../include/grid/drogon.multnum                                                                                                      
+    51 READING MULTNUM 
+               END OF INCLUDE FILE 
+    52 READING INCLUDE ../include/grid/drogon.multregt                                                                                                     
+    53 READING MULTREGT
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      1 AND      8                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      1 AND     15                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      8 AND     15                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      2 AND      9                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      2 AND     16                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      9 AND     16                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      3 AND     10                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      3 AND     17                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS     10 AND     17                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      4 AND     11                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      4 AND     18                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS     11 AND     18                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      5 AND     12                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      5 AND     19                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS     12 AND     19                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      6 AND     13                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      6 AND     20                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS     13 AND     20                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      7 AND     14                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS      7 AND     21                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS     14 AND     21                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS     12 AND      2                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS     12 AND      9                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS     12 AND     16                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS     12 AND      6                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS     12 AND     13                      
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @            THE MULTNUM ARRAY WILL BE USED WITH THE MULTREGT               
+ @            KEYWORD BETWEEN REGIONS     12 AND     20                      
+               END OF INCLUDE FILE 
+    54 READING EDIT    
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @               2535 PINCH-OUT CONNECTIONS GENERATED                        
+    55 READING INCLUDE ../include/edit/drogon.trans                                                                                                        
+    56 READING MULTIPLY
+    57 READING EDITNNC 
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @              252 OUT OF   7355 NNCS DEFINED UNDER EDITNNC  WERE           
+ @           NOT FOUND. SET MNEMONIC ALLNNC IN RPTGRID TO                    
+ @           OBTAIN A FULL LISTING OF THESE MISSING NNCS                     
+               END OF INCLUDE FILE 
+    58 READING PROPS   
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @                5   NON-NEIGHBOUR CONNECTIONS NNCS HAVE BEEN               
+ @           DELETED SINCE THEY HAVE ZERO TRANSMISSIBILITY                   
+ @           AFTER PROCESSING THE EDIT SECTION                               
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           PRE-PROCESSING HAS FOUND 2423 NON-NEIGHBOUR CONNECTIONS         
+ @           WHICH EITHER JOIN ADJACENT CELLS OR CAN BE TREATED AS A         
+ @           NORMAL CONNECTION. THE TRANSMISSIBILITY HAS BEEN ADDED TO       
+ @           THE APPROPRIATE CELL TRANSMISSIBILITY AND THE                   
+ @           NON-NEIGHBOUR CONNECTION REMOVED FROM THE SIMULATION            
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           A FULL LISTING OF THESE NNCS CAN BE OBTAINED BY SETTING         
+ @           THE ALLNNC MNEMONIC IN RPTGRID. THE OUTPUT HAS THE              
+ @           TITLE MNEMONIC DEL-NNC                                          
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @                286 NON-NEIGHBOUR CONNECTIONS HAVE BEEN IGNORED            
+ @           AS THEIR TRANSMISSIBILITY IS LESS THAN 0.100000E-05             
+ @                112 OF THESE ARE Z-PINCHOUTS.                              
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           7049 NON-NEIGHBOUR CONNECTIONS PRESENT                          
+
+ @--COMMENT  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           LEFT HANDED GRIDS MAY NOT BE SUPPORTED                          
+ @            IN ALL PRE AND POST PROCESSORS                                 
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           NUMBER OF ACTIVE CELLS IS 71098                                 
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THE MEMORY REQUIRED TO PROCESS THE SOLUTION SECTION IS          
+ @               169050 KBYTES                                               
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @              62973 CHARACTER VARIABLES USED                               
+    59 READING FILLEPS 
+    60 READING INCLUDE ../include/props/drogon.sattab                                                                                                      
+    61 READING SWOF    
+    62 READING SGOF    
+               END OF INCLUDE FILE 
+    63 READING IMPORT  
+    64 READING SWATINIT
+    65 READING IMPORT  
+    66 READING SWL     
+    67 READING IMPORT  
+    68 READING SWCR    
+    69 READING IMPORT  
+    70 READING SGU     
+    71 READING INCLUDE ../include/props/drogon.pvt                                                                                                         
+    72 READING ROCKOPTS
+    73 READING ROCK    
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           ALTHOUGH ROCK DATA WAS ASSOCIATED WITH ROCKNUM                  
+ @           THE NUMBER OF REGIONS WAS NOT EXPLICITLY SET                    
+ @           USING ARGUMENT 13 OF KEYWORD TABDIMS                            
+ @           ROCK WILL BE ASSOCIATED WITH PVTNUM INSTEAD                     
+    74 READING PVTW    
+    75 READING DENSITY 
+    76 READING PVTO    
+    77 READING PVTG    
+               END OF INCLUDE FILE 
+    78 READING TRACER  
+    79 READING EXTRAPMS
+    80 READING REGIONS 
+    81 READING INCLUDE ../include/regions/drogon.eqlnum                                                                                                    
+    82 READING EQLNUM  
+               END OF INCLUDE FILE 
+    83 READING INCLUDE ../include/regions/drogon.fipnum                                                                                                    
+    84 READING FIPNUM  
+               END OF INCLUDE FILE 
+    85 READING INCLUDE ../include/regions/drogon.fipzon                                                                                                    
+    86 READING FIPZON  
+               END OF INCLUDE FILE 
+    87 READING INCLUDE ../include/regions/drogon.satnum                                                                                                    
+    88 READING SATNUM  
+               END OF INCLUDE FILE 
+    89 READING INCLUDE ../include/regions/drogon.pvtnum                                                                                                    
+    90 READING PVTNUM  
+               END OF INCLUDE FILE 
+    91 READING SOLUTION
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THERE IS A TRANSMISSIBILITY IN THE  X  DIRECTION                
+ @           BETWEEN CELLS 26,6,1 AND 27,6,1                                 
+ @           THESE CELLS ARE IN DIFFERENT PVT REGIONS                        
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THERE IS A TRANSMISSIBILITY IN THE  X  DIRECTION                
+ @           BETWEEN CELLS 27,6,1 AND 28,6,1                                 
+ @           THESE CELLS ARE IN DIFFERENT PVT REGIONS                        
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THERE IS A TRANSMISSIBILITY IN THE  X  DIRECTION                
+ @           BETWEEN CELLS 25,7,1 AND 26,7,1                                 
+ @           THESE CELLS ARE IN DIFFERENT PVT REGIONS                        
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THERE IS A TRANSMISSIBILITY IN THE  X  DIRECTION                
+ @           BETWEEN CELLS 27,7,1 AND 28,7,1                                 
+ @           THESE CELLS ARE IN DIFFERENT PVT REGIONS                        
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THERE IS A TRANSMISSIBILITY IN THE  X  DIRECTION                
+ @           BETWEEN CELLS 24,8,1 AND 25,8,1                                 
+ @           THESE CELLS ARE IN DIFFERENT PVT REGIONS                        
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THERE IS A TRANSMISSIBILITY IN THE  X  DIRECTION                
+ @           BETWEEN CELLS 27,8,1 AND 28,8,1                                 
+ @           THESE CELLS ARE IN DIFFERENT PVT REGIONS                        
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THERE IS A TRANSMISSIBILITY IN THE  X  DIRECTION                
+ @           BETWEEN CELLS 24,9,1 AND 25,9,1                                 
+ @           THESE CELLS ARE IN DIFFERENT PVT REGIONS                        
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THERE IS A TRANSMISSIBILITY IN THE  X  DIRECTION                
+ @           BETWEEN CELLS 27,9,1 AND 28,9,1                                 
+ @           THESE CELLS ARE IN DIFFERENT PVT REGIONS                        
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THERE IS A TRANSMISSIBILITY IN THE  X  DIRECTION                
+ @           BETWEEN CELLS 23,10,1 AND 24,10,1                               
+ @           THESE CELLS ARE IN DIFFERENT PVT REGIONS                        
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THERE IS A TRANSMISSIBILITY IN THE  X  DIRECTION                
+ @           BETWEEN CELLS 26,10,1 AND 27,10,1                               
+ @           THESE CELLS ARE IN DIFFERENT PVT REGIONS                        
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           NO FURTHER MESSAGES ABOUT                                       
+ @           PVT REGION CONNECTION CONSISTENCY                               
+ @           WILL BE EMITTED.                                                
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           THE OUTPUT LIMIT FOR THESE MESSAGES                             
+ @           CAN BE CHANGED WITH ITEM 13 OF THE                              
+ @           MESSAGES KEYWORD OR WITH ITEM 220                               
+ @           OF THE OPTIONS KEYWORD.                                         
+    92 READING INCLUDE ../include/solution/drogon.equil                                                                                                    
+    93 READING EQUIL   
+               END OF INCLUDE FILE 
+    94 READING INCLUDE ../include/solution/drogon.rxvd                                                                                                     
+    95 READING RSVD    
+    96 READING RVVD    
+               END OF INCLUDE FILE 
+    97 READING INCLUDE ../include/solution/drogon.thpres                                                                                                   
+    98 READING THPRES  
+               END OF INCLUDE FILE 
+    99 READING TVDPFWT1
+   100 READING TVDPFWT2
+   101 READING RPTSOL  
+   102 READING RPTRST  
+   103 READING SUMMARY 
+1                             **********************************************************************   1
+  THPRES   AT      0.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT   0     1 JAN 2018   *  RUN                                                                   * RUN AT 09:06 ON 28 MAY 2025 
+                              **************************************************************************
+ 
+
+ LIST OF ALL NON-ZERO THRESHOLD PRESSURES
+ ----------------------------------------
+
+    FLOW FROM REGION              TO REGION                     THRESHOLD PRESSURE
+    ----------------              ---------                     -------------------
+         1                             2                           0.572232        BARSA 
+         1                             4                            1.14520        BARSA 
+         2                             1                           0.572232        BARSA 
+         3                             4                           0.586856        BARSA 
+         4                             1                            1.14520        BARSA 
+         4                             3                           0.586856        BARSA 
+         6                             7                           0.521083        BARSA 
+         7                             6                           0.521083        BARSA 
+    ----------------              ---------                     -------------------
+   104 READING SUMTHIN 
+   105 READING INCLUDE ../include/summary/drogon.summary                                                                                                   
+   106 READING FOPR    
+   107 READING FOPRH   
+   108 READING FGPR    
+   109 READING FGPRH   
+   110 READING FWPR    
+   111 READING FWPRH   
+   112 READING FLPR    
+   113 READING FLPRH   
+   114 READING FVPR    
+   115 READING FOPRF   
+   116 READING FOPRS   
+   117 READING FGSR    
+   118 READING FGPRF   
+   119 READING FGPRS   
+   120 READING FOPP    
+   121 READING FWPP    
+   122 READING FGPP    
+   123 READING FMWPR   
+   124 READING FMWIN   
+   125 READING FVIR    
+   126 READING FWIR    
+   127 READING FWIRH   
+   128 READING FGIR    
+   129 READING FGIRH   
+   130 READING FGLIR   
+   131 READING FMCTP   
+   132 READING FVPT    
+   133 READING FOPT    
+   134 READING FOPTH   
+   135 READING FWPT    
+   136 READING FWPTH   
+   137 READING FGPT    
+   138 READING FGPTH   
+   139 READING FWIT    
+   140 READING FWITH   
+   141 READING FGIT    
+   142 READING FGITH   
+   143 READING FOPTF   
+   144 READING FOPTS   
+   145 READING FWIP    
+   146 READING FOIP    
+   147 READING FGIP    
+   148 READING FWCT    
+   149 READING FWCTH   
+   150 READING FGOR    
+   151 READING FGORH   
+   152 READING FGLR    
+   153 READING FWGR    
+   154 READING FPR     
+   155 READING RPR     
+   156 READING ROIP    
+   157 READING ROE     
+   158 READING ROIPL   
+   159 READING ROIPG   
+   160 READING RGIP    
+   161 READING RGIPL   
+   162 READING RGIPG   
+   163 READING RGPR    
+   164 READING RGPT    
+   165 READING GMWPR   
+   166 READING GMWIN   
+   167 READING GGLIR   
+   168 READING GOPR    
+   169 READING GOPRH   
+   170 READING GGPR    
+   171 READING GGPRH   
+   172 READING GWPR    
+   173 READING GWPRH   
+   174 READING GVPR    
+   175 READING GLPR    
+   176 READING GOPRF   
+   177 READING GOPRS   
+   178 READING GGPRF   
+   179 READING GGPRS   
+   180 READING GWCT    
+   181 READING GWCTH   
+   182 READING GGOR    
+   183 READING GGORH   
+   184 READING GWGR    
+   185 READING GGLR    
+   186 READING GOPT    
+   187 READING GOPTH   
+   188 READING GGPT    
+   189 READING GGPTH   
+   190 READING GWPT    
+   191 READING GWPTH   
+   192 READING GVPT    
+   193 READING GLPT    
+   194 READING GOPTF   
+   195 READING GOPTS   
+   196 READING GGPTF   
+   197 READING GGPTS   
+   198 READING GWIR    
+   199 READING GVIR    
+   200 READING GWIRH   
+   201 READING GGIR    
+   202 READING GGIRH   
+   203 READING GPR     
+   204 READING GOPP    
+   205 READING GGPP    
+   206 READING GWPP    
+   207 READING GMCTP   
+   208 READING WOPR    
+   209 READING WOPRH   
+   210 READING WGPR    
+   211 READING WGPRH   
+   212 READING WWPR    
+   213 READING WWPRH   
+   214 READING WLPR    
+   215 READING WLPRH   
+   216 READING WOPT    
+   217 READING WWPT    
+   218 READING WGPT    
+   219 READING WOPTH   
+   220 READING WWPTH   
+   221 READING WGPTH   
+   222 READING WWCT    
+   223 READING WWCTH   
+   224 READING WGOR    
+   225 READING WGORH   
+   226 READING WWIR    
+   227 READING WWIRH   
+   228 READING WGIR    
+   229 READING WGIRH   
+   230 READING WWIT    
+   231 READING WWITH   
+   232 READING WGIT    
+   233 READING WGITH   
+   234 READING WBHP    
+   235 READING WTHP    
+   236 READING WPI     
+   237 READING WVPR    
+   238 READING WBP     
+   239 READING WBP4    
+   240 READING WBP9    
+   241 READING WMCTL   
+   242 READING WSTAT   
+   243 READING WGLIR   
+   244 READING WOGLR   
+   245 READING WTPRWT1 
+   246 READING WTPRWT2 
+   247 READING WTPTWT1 
+   248 READING WTPTWT2 
+   249 READING WTPCWT1 
+   250 READING WTPCWT2 
+   251 READING WTIRWT1 
+   252 READING WTIRWT2 
+   253 READING WTITWT1 
+   254 READING WTITWT2 
+   255 READING WTICWT1 
+   256 READING WTICWT2 
+   257 READING TCPU    
+   258 READING TCPUDAY 
+   259 READING WOPRL   
+   260 READING WWPRL   
+   261 READING WGPRL   
+   262 READING WWIRL   
+               END OF INCLUDE FILE 
+   263 READING SCHEDULE
+   264 READING INCLUDE ../include/schedule/vfp/A-1.inc                                                                                                     
+   265 READING VFPPROD 
+               END OF INCLUDE FILE 
+   266 READING INCLUDE ../include/schedule/vfp/A-2.inc                                                                                                     
+   267 READING VFPPROD 
+               END OF INCLUDE FILE 
+   268 READING INCLUDE ../include/schedule/vfp/A-3.inc                                                                                                     
+   269 READING VFPPROD 
+               END OF INCLUDE FILE 
+   270 READING INCLUDE ../include/schedule/vfp/A-4.inc                                                                                                     
+   271 READING VFPPROD 
+               END OF INCLUDE FILE 
+   272 READING INCLUDE ../include/schedule/drogon_hist.sch                                                                                                 
+   273 READING WELSPECS
+   274 READING COMPORD 
+   275 READING GRUPTREE
+   276 READING COMPDAT 
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           WELL R_A2     CONNECTS WITH A DEAD BLOCK                        
+ @           (  22  30  12). THIS CONNECTION WILL BE IGNORED.                
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           CONNECTION (  22  29  27) IN WELL R_A2                          
+ @           HAS ROCK Z-PERMEABILITY   0.0000E+00 .                          
+ @           RESETTING KZ TO 10**(-10)                                       
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           WELL R_A3     CONNECTS WITH A DEAD BLOCK                        
+ @           (  29  41  14). THIS CONNECTION WILL BE IGNORED.                
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           WELL R_A3     CONNECTS WITH A DEAD BLOCK                        
+ @           (  29  41  17). THIS CONNECTION WILL BE IGNORED.                
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           WELL R_A5     CONNECTS WITH A DEAD BLOCK                        
+ @           (  31  20   9). THIS CONNECTION WILL BE IGNORED.                
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           WELL R_A5     CONNECTS WITH A DEAD BLOCK                        
+ @           (  31  20  10). THIS CONNECTION WILL BE IGNORED.                
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           WELL R_A5     CONNECTS WITH A DEAD BLOCK                        
+ @           (  31  21  10). THIS CONNECTION WILL BE IGNORED.                
+
+ @--WARNING  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           WELL R_A6     CONNECTS WITH A DEAD BLOCK                        
+ @           (  17  42  18). THIS CONNECTION WILL BE IGNORED.                
+   277 READING WCONHIST
+   278 READING WRFTPLT 
+   279 READING TUNING  
+   280 READING RPTRST  
+   281 READING DATES   
+
+ @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2018):
+ @           GRAPHICS ONLY RESTART FILE WRITTEN   REPORT     0               
+ @           RESTART INCLUDES BUBBLE AND DEW POINT PRESSURES                 
+ @                            SATURATED GOR                                  
+ @                            SATURATED OGR                                  
+1                             **********************************************************************   2
+  SIMULATE AT      0.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT   0     1 JAN 2018   *  RUN                                                                   * RUN AT 09:06 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP    1 TIME=      1.00  DAYS (    +1.0  DAYS INIT  1 ITS) (2-JAN-2018)       
+  PAV=   300.7  BARSA  WCT= 0.00 GOR= 0.00000   SM3/SM3 WGR= 0.00000   SM3/SM3   
+
+ STEP    2 TIME=      4.00  DAYS (    +3.0  DAYS REPT  1 ITS) (5-JAN-2018)       
+  PAV=   300.7  BARSA  WCT= 0.00 GOR= 0.00000   SM3/SM3 WGR= 0.00000   SM3/SM3   
+   282 READING WELSPECS
+   283 READING COMPORD 
+   284 READING COMPDAT 
+   285 READING COMPLUMP
+   286 READING WCONHIST
+
+ @--MESSAGE  AT TIME        4.0   DAYS    ( 5-JAN-2018):
+ @           OPENING WELL A1       AT TIME      4.00   DAYS                  
+ @           CONTROLLED BY RESERVOIR FLUID VOLUME RATE                       
+   287 READING WELTARG 
+   288 READING DATES   
+1                             **********************************************************************   3
+  SIMULATE AT      4.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT   1     5 JAN 2018   *  RUN                                                                   * RUN AT 09:06 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP    3 TIME=      5.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (6-JAN-2018)       
+  PAV=   300.4  BARSA  WCT=0.000 GOR=   140.82  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP    4 TIME=      8.00  DAYS (    +3.0  DAYS MAXF  3 ITS) (9-JAN-2018)       
+  PAV=   299.7  BARSA  WCT=0.000 GOR=   140.82  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP    5 TIME=     17.00  DAYS (    +9.0  DAYS MAXF  5 ITS) (18-JAN-2018)      
+  PAV=   297.9  BARSA  WCT=0.000 GOR=   140.82  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP    6 TIME=     24.00  DAYS (    +7.0  DAYS HALF  3 ITS) (25-JAN-2018)      
+  PAV=   296.6  BARSA  WCT=0.000 GOR=   140.82  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP    7 TIME=     31.00  DAYS (    +7.0  DAYS REPT  2 ITS) (1-FEB-2018)       
+  PAV=   295.4  BARSA  WCT=0.000 GOR=   140.82  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   289 READING WCONHIST
+   290 READING DATES   
+1                             **********************************************************************   4
+  SIMULATE AT     31.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT   2     1 FEB 2018   *  RUN                                                                   * RUN AT 09:06 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP    8 TIME=     32.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (2-FEB-2018)       
+  PAV=   295.2  BARSA  WCT=0.000 GOR=   140.82  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP    9 TIME=     35.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-FEB-2018)       
+  PAV=   294.7  BARSA  WCT=0.000 GOR=   140.82  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   10 TIME=     44.00  DAYS (    +9.0  DAYS MAXF  5 ITS) (14-FEB-2018)      
+  PAV=   293.3  BARSA  WCT=0.000 GOR=   140.82  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   11 TIME=     59.00  DAYS (   +15.0  DAYS REPT  4 ITS) (1-MAR-2018)       
+  PAV=   291.3  BARSA  WCT=0.000 GOR=   140.71  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   291 READING WCONHIST
+   292 READING WRFTPLT 
+   293 READING DATES   
+1                             **********************************************************************   5
+  SIMULATE AT     59.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT   3     1 MAR 2018   *  RUN                                                                   * RUN AT 09:06 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   12 TIME=     60.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (2-MAR-2018)       
+  PAV=   291.2  BARSA  WCT=0.000 GOR=   140.64  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   13 TIME=     63.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-MAR-2018)       
+  PAV=   290.8  BARSA  WCT=0.000 GOR=   140.46  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   14 TIME=     68.00  DAYS (    +5.0  DAYS REPT  2 ITS) (10-MAR-2018)      
+  PAV=   290.3  BARSA  WCT=0.000 GOR=   140.21  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   294 READING WELSPECS
+   295 READING COMPORD 
+   296 READING COMPDAT 
+   297 READING COMPLUMP
+   298 READING WCONHIST
+
+ @--MESSAGE  AT TIME       68.0   DAYS    (10-MAR-2018):
+ @           OPENING WELL A2       AT TIME     68.00   DAYS                  
+ @           CONTROLLED BY RESERVOIR FLUID VOLUME RATE                       
+   299 READING WELTARG 
+   300 READING DATES   
+1                             **********************************************************************   6
+  SIMULATE AT     68.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT   4    10 MAR 2018   *  RUN                                                                   * RUN AT 09:06 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   15 TIME=     69.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (11-MAR-2018)      
+  PAV=   289.9  BARSA  WCT=0.000 GOR=   140.50  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   16 TIME=     72.00  DAYS (    +3.0  DAYS MAXF  5 ITS) (14-MAR-2018)      
+  PAV=   289.1  BARSA  WCT=0.000 GOR=   140.43  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   17 TIME=     78.65  DAYS (    +6.7  DAYS TRNC  6 ITS) (20-MAR-2018)      
+  PAV=   287.5  BARSA  WCT=0.000 GOR=   140.30  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   18 TIME=     88.00  DAYS (    +9.3  DAYS REPT  4 ITS) (30-MAR-2018)      
+  PAV=   285.7  BARSA  WCT=0.001 GOR=   137.96  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   301 READING WCONHIST
+   302 READING DATES   
+1                             **********************************************************************   7
+  SIMULATE AT     88.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT   5    30 MAR 2018   *  RUN                                                                   * RUN AT 09:06 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   19 TIME=     89.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (31-MAR-2018)      
+  PAV=   285.5  BARSA  WCT=0.001 GOR=   137.76  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   20 TIME=     90.00  DAYS (    +1.0  DAYS REPT  2 ITS) (1-APR-2018)       
+  PAV=   285.4  BARSA  WCT=0.001 GOR=   137.55  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   303 READING WCONHIST
+   304 READING DATES   
+1                             **********************************************************************   8
+  SIMULATE AT     90.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT   6     1 APR 2018   *  RUN                                                                   * RUN AT 09:06 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   21 TIME=     91.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (2-APR-2018)       
+  PAV=   285.2  BARSA  WCT=0.001 GOR=   137.37  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   22 TIME=     94.00  DAYS (    +3.0  DAYS MAXF  3 ITS) (5-APR-2018)       
+  PAV=   284.7  BARSA  WCT=0.001 GOR=   137.26  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   23 TIME=    103.00  DAYS (    +9.0  DAYS MAXF  4 ITS) (14-APR-2018)      
+  PAV=   283.4  BARSA  WCT=0.001 GOR=   137.95  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   24 TIME=    110.00  DAYS (    +7.0  DAYS HALF  3 ITS) (21-APR-2018)      
+  PAV=   282.4  BARSA  WCT=0.001 GOR=   137.75  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   25 TIME=    117.00  DAYS (    +7.0  DAYS REPT  4 ITS) (28-APR-2018)      
+  PAV=   281.5  BARSA  WCT=0.001 GOR=   136.93  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   305 READING WCONHIST
+   306 READING WRFTPLT 
+   307 READING DATES   
+1                             **********************************************************************   9
+  SIMULATE AT    117.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT   7    28 APR 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   26 TIME=    118.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (29-APR-2018)      
+  PAV=   281.3  BARSA  WCT=0.001 GOR=   136.93  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   27 TIME=    120.00  DAYS (    +2.0  DAYS REPT  2 ITS) (1-MAY-2018)       
+  PAV=   281.1  BARSA  WCT=0.001 GOR=   136.64  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   308 READING WCONHIST
+   309 READING DATES   
+1                             **********************************************************************  10
+  SIMULATE AT    120.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT   8     1 MAY 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   28 TIME=    121.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (2-MAY-2018)       
+  PAV=   280.9  BARSA  WCT=0.001 GOR=   136.68  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   29 TIME=    124.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-MAY-2018)       
+  PAV=   280.6  BARSA  WCT=0.001 GOR=   136.39  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   30 TIME=    127.00  DAYS (    +3.0  DAYS REPT  2 ITS) (8-MAY-2018)       
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   136.20  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   310 READING WELSPECS
+   311 READING COMPORD 
+   312 READING COMPDAT 
+
+ @--WARNING  AT TIME      127.0   DAYS    ( 8-MAY-2018):
+ @           WELL A5       CONNECTS WITH A DEAD BLOCK                        
+ @           (  31  20   9). THIS CONNECTION WILL BE IGNORED.                
+
+ @--WARNING  AT TIME      127.0   DAYS    ( 8-MAY-2018):
+ @           WELL A5       CONNECTS WITH A DEAD BLOCK                        
+ @           (  31  20  10). THIS CONNECTION WILL BE IGNORED.                
+
+ @--WARNING  AT TIME      127.0   DAYS    ( 8-MAY-2018):
+ @           WELL A5       CONNECTS WITH A DEAD BLOCK                        
+ @           (  31  21  10). THIS CONNECTION WILL BE IGNORED.                
+
+ @--WARNING  AT TIME      127.0   DAYS    ( 8-MAY-2018):
+ @           NO FURTHER MESSAGES ABOUT                                       
+ @           WELLS CONNECTING WITH DEAD BLOCKS                               
+ @           WILL BE EMITTED.                                                
+
+ @--MESSAGE  AT TIME      127.0   DAYS    ( 8-MAY-2018):
+ @           THE OUTPUT LIMIT FOR THESE MESSAGES                             
+ @           CAN BE CHANGED WITH ITEM 13 OF THE                              
+ @           MESSAGES KEYWORD OR WITH ITEM 220                               
+ @           OF THE OPTIONS KEYWORD.                                         
+   313 READING COMPLUMP
+   314 READING WCONHIST
+   315 READING WCONINJH
+
+ @--MESSAGE  AT TIME      127.0   DAYS    ( 8-MAY-2018):
+ @           OPENING WELL A5       AT TIME    127.00   DAYS                  
+ @           CONTROLLED BY WATER RATE                                        
+   316 READING DATES   
+1                             **********************************************************************  11
+  SIMULATE AT    127.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT   9     8 MAY 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   31 TIME=    128.00  DAYS (    +1.0  DAYS MAXW  3 ITS) (9-MAY-2018)       
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   133.82  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   32 TIME=    130.80  DAYS (    +2.8  DAYS TRNC  3 ITS) (11-MAY-2018)      
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   134.07  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   33 TIME=    137.47  DAYS (    +6.7  DAYS TRNC  5 ITS) (18-MAY-2018)      
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   135.63  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   34 TIME=    144.23  DAYS (    +6.8  DAYS HALF  3 ITS) (25-MAY-2018)      
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   136.40  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   35 TIME=    151.00  DAYS (    +6.8  DAYS REPT  3 ITS) (1-JUN-2018)       
+  PAV=   280.1  BARSA  WCT=0.001 GOR=   136.67  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   317 READING WCONHIST
+   318 READING DATES   
+1                             **********************************************************************  12
+  SIMULATE AT    151.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  10     1 JUN 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   36 TIME=    152.00  DAYS (    +1.0  DAYS REPT  3 ITS) (2-JUN-2018)       
+  PAV=   280.1  BARSA  WCT=0.001 GOR=   134.58  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   319 READING WCONHIST
+   320 READING DATES   
+1                             **********************************************************************  13
+  SIMULATE AT    152.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  11     2 JUN 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   37 TIME=    153.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (3-JUN-2018)       
+  PAV=   280.1  BARSA  WCT=0.001 GOR=   134.88  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   38 TIME=    155.50  DAYS (    +2.5  DAYS HALF  2 ITS) (5-JUN-2018)       
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   135.27  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   39 TIME=    158.00  DAYS (    +2.5  DAYS REPT  2 ITS) (8-JUN-2018)       
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   135.69  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   321 READING WTRACER 
+   322 READING WCONHIST
+   323 READING DATES   
+1                             **********************************************************************  14
+  SIMULATE AT    158.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  12     8 JUN 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   40 TIME=    159.00  DAYS (    +1.0  DAYS REPT  1 ITS) (9-JUN-2018)       
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   135.83  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   324 READING WTRACER 
+   325 READING WCONHIST
+   326 READING DATES   
+1                             **********************************************************************  15
+  SIMULATE AT    159.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  13     9 JUN 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   41 TIME=    160.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (10-JUN-2018)      
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   135.96  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   42 TIME=    163.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (13-JUN-2018)      
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   136.30  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   43 TIME=    172.00  DAYS (    +9.0  DAYS REPT  6 ITS) (22-JUN-2018)      
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   137.18  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   327 READING WCONHIST
+   328 READING DATES   
+1                             **********************************************************************  16
+  SIMULATE AT    172.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  14    22 JUN 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   44 TIME=    173.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (23-JUN-2018)      
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   137.11  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   45 TIME=    176.00  DAYS (    +3.0  DAYS MAXF  3 ITS) (26-JUN-2018)      
+  PAV=   280.2  BARSA  WCT=0.001 GOR=   137.53  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   46 TIME=    180.00  DAYS (    +4.0  DAYS REPT  4 ITS) (30-JUN-2018)      
+  PAV=   280.2  BARSA  WCT=0.002 GOR=   137.94  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   329 READING WCONHIST
+   330 READING RPTSCHED
+   331 READING RPTRST  
+
+ @--MESSAGE  AT TIME      180.0   DAYS    (30-JUN-2018):
+ @           ROCKC TRAN_ OUTPUT HAS BEEN RENAMED TO PERM_                    
+ @           FROM 2013.1 FOR COMPATIBILITY WITH E300                         
+   332 READING DATES   
+1                             **********************************************************************  17
+  SIMULATE AT    180.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  15    30 JUN 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   47 TIME=    181.00  DAYS (    +1.0  DAYS REPT  1 ITS) (1-JLY-2018)       
+  PAV=   280.2  BARSA  WCT=0.002 GOR=   137.86  SM3/SM3 WGR=   0.0000  SM3/SM3   
+1                             **********************************************************************  18
+  BALANCE  AT    181.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  16     1 JLY 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+
+                                                     ==================================================
+                                                     :               FIELD TOTALS                     :
+                                                     :         PAV =        280.21  BARSA             :
+                                                     :         PORV=    543870734.   RM3              :
+                                                     :(PRESSURE IS WEIGHTED BY HYDROCARBON PORE VOLUME:
+                                                     : PORE VOLUMES ARE TAKEN AT REFERENCE CONDITIONS):
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :     44364804.       172558.      44537362.:     458909720. :   1230565497.   6292414038.    7522979535.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW THROUGH WELLS    :                                   1104270.:       -431268. :                                 152421920.:
+ :WELL  MATERIAL BAL. ERROR:                                        -0.:            -0. :                                         0.:
+ :FIELD MATERIAL BAL. ERROR:                                       112.:          -118. :                                     23876.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :     45456828.       184916.      45641745.:     458478335. :   1201546352.   6473878978.    7675425331.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    1    :
+                                                :     PAV =        286.75  BARSA:
+                                                :     PORV=     92144333.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      1966937.         1535.       1968472.:      86354207. :      7175821.    279733307.     286909129.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :         4483.        -1380.          3103.:        143034. :     -9884804.       609805.      -9274999.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         6.:           119. :                                      3820.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      1971580.            0.       1971580.:      86497360. :            0.    277637950.     277637950.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :         1366.            0.          1366.:         42730. :            0.       192362.        192362.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:        176667. :            0.            0.             0.:
+ :OUTFLOW TO REGION   4    :         -409.        -1182.         -1590.:         -5646. :     -8453611.       -78190.      -8531801.:
+ :OUTFLOW TO REGION   8    :         3237.           -0.          3237.:        -81357. :           -0.       459118.        459118.:
+ :OUTFLOW TO REGION   9    :          365.           -0.           365.:          3137. :            0.        51411.         51411.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:         -2450. :            0.            0.             0.:
+ :OUTFLOW TO REGION  11    :           -0.         -199.          -199.:            -6. :     -1431157.           -0.      -1431157.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:             0. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :           14.            0.            14.:          9960. :            0.         1946.          1946.:
+ :OUTFLOW TO REGION  18    :          -90.           -0.           -90.:            -1. :          -36.       -16842.        -16878.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    2    :
+                                                :     PAV =        283.02  BARSA:
+                                                :     PORV=     23847184.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      7293593.           -0.       7293593.:      12900883. :           -0.   1027083711.    1027083711.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       119092.            0.        119092.:        -89595. :            0.     16770578.      16770578.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         6.:             5. :                                       866.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      7412691.            0.       7412691.:      12811294. :            0.   1043855155.    1043855155.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :        -1366.           -0.         -1366.:        -42730. :            0.      -192362.       -192362.:
+ :OUTFLOW TO REGION   3    :       202730.            0.        202730.:        -60822. :           -0.     28548390.      28548390.:
+ :OUTFLOW TO REGION   5    :          203.            0.           203.:            28. :            0.        28540.         28540.:
+ :OUTFLOW TO REGION   6    :            0.            0.             0.:         12133. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :            0.            0.             0.:            -2. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :        -6146.            0.         -6146.:           -11. :            0.      -865461.       -865461.:
+ :OUTFLOW TO REGION  12    :          -26.            0.           -26.:            -0. :           -0.        -3721.         -3721.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:            20. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :            4.            0.             4.:             1. :            0.          526.           526.:
+ :OUTFLOW TO REGION  19    :       -90645.            0.        -90645.:          -243. :            0.    -12764566.     -12764566.:
+ :OUTFLOW TO REGION  20    :        14339.           -0.         14339.:          2032. :            0.      2019232.       2019232.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    3    :
+                                                :     PAV =        276.47  BARSA:
+                                                :     PORV=     16265885.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      2269290.          507.       2269797.:      12557929. :      3035581.    319000804.     322036385.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :      -204514.           -0.       -204514.:       -221325. :            0.    -29179890.     -29179890.:
+ :OUTFLOW THROUGH WELLS    :                                    397322.:           538. :                                  53924444.:
+ :MATERIAL BALANCE ERROR.  :                                        15.:            37. :                                      5215.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      2462620.            0.       2462620.:      12337179. :           -0.    346786153.     346786153.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :            0.            0.             0.:       -176667. :            0.            0.             0.:
+ :OUTFLOW TO REGION   2    :      -202730.           -0.       -202730.:         60822. :            0.    -28548390.     -28548390.:
+ :OUTFLOW TO REGION   4    :            0.            0.             0.:         -9897. :            0.            0.             0.:
+ :OUTFLOW TO REGION   5    :            0.            0.             0.:           155. :            0.            0.             0.:
+ :OUTFLOW TO REGION   6    :            0.            0.             0.:        -50897. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:          7102. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :            0.            0.             0.:        -65083. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :         -640.           -0.          -640.:          -821. :            0.       -90135.        -90135.:
+ :OUTFLOW TO REGION  11    :          114.            0.           114.:         -6372. :            0.        16350.         16350.:
+ :OUTFLOW TO REGION  13    :          407.            0.           407.:         48527. :            0.        57244.         57244.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:             0. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:         -2039. :            0.            0.             0.:
+ :OUTFLOW TO REGION  18    :        -1780.           -0.         -1780.:        -44092. :            0.      -631035.       -631035.:
+ :OUTFLOW TO REGION  20    :          114.            0.           114.:         17936. :            0.        16077.         16077.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    4    :
+                                                :     PAV =        291.03  BARSA:
+                                                :     PORV=      7720051.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       241624.        97544.        339168.:       4124354. :    699412207.     45778637.     745190844.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :          641.         1648.          2289.:         23343. :     11600233.       122453.      11722686.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         0.:           -51. :                                      7624.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       232168.       109289.        341457.:       4147646. :    711432520.     45488634.     756921154.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :          409.         1182.          1590.:          5646. :      8453611.        78190.       8531801.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:          9897. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :            0.            0.             0.:           109. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:             2. :            0.            0.             0.:
+ :OUTFLOW TO REGION  11    :          232.          467.           699.:          7689. :      3146622.        44263.       3190885.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    5    :
+                                                :     PAV =        280.57  BARSA:
+                                                :     PORV=      2279667.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      1047597.            0.       1047597.:        743755. :            0.    147522636.     147522636.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :         6976.           -0.          6976.:           -15. :            0.       982404.        982404.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -0.:            -0. :                                        -9.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      1054573.            0.       1054573.:        743740. :            0.    148505030.     148505030.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :         -203.           -0.          -203.:           -28. :           -0.       -28540.        -28540.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:          -155. :            0.            0.             0.:
+ :OUTFLOW TO REGION   6    :            0.            0.             0.:            -4. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :          -30.           -0.           -30.:             1. :           -0.        -4200.         -4200.:
+ :OUTFLOW TO REGION  12    :         -220.            0.          -220.:            -0. :            0.       -31049.        -31049.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:           171. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :           -0.           -0.            -0.:             0. :           -0.          -69.           -69.:
+ :OUTFLOW TO REGION  20    :         7430.           -0.          7430.:             0. :            0.      1046262.       1046262.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    6    :
+                                                :     PAV =        261.54  BARSA:
+                                                :     PORV=     16715360.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      7095327.         3742.       7099069.:       6165789. :     23105231.    977513457.    1000618688.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        -2047.            0.         -2047.:         52366. :            0.      -287571.       -287571.:
+ :OUTFLOW THROUGH WELLS    :                                    242726.:       -219609. :                                  33265427.:
+ :MATERIAL BALANCE ERROR.  :                                        44.:             3. :                                     -7101.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      7339792.            0.       7339792.:       5998549. :            0.   1033589443.    1033589443.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :            0.            0.             0.:        -12133. :            0.            0.             0.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:         50897. :            0.            0.             0.:
+ :OUTFLOW TO REGION   5    :            0.            0.             0.:             4. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :         1499.            0.          1499.:         12715. :            0.       211073.        211073.:
+ :OUTFLOW TO REGION  13    :        -3546.           -0.         -3546.:           886. :            0.      -498644.       -498644.:
+ :OUTFLOW TO REGION  20    :            0.            0.             0.:            -3. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    7    :
+                                                :     PAV =        288.91  BARSA:
+                                                :     PORV=     31732729.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :         1818.           -0.          1818.:      30715501. :           -0.       255993.        255993.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        -1818.           -0.         -1818.:         34479. :            0.      -255985.       -255985.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -0.:            -7. :                                        -8.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :            0.            0.             0.:      30749973. :            0.            0.             0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:         -7102. :            0.            0.             0.:
+ :OUTFLOW TO REGION   6    :        -1499.           -0.         -1499.:        -12715. :            0.      -211073.       -211073.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:           -78. :            0.            0.             0.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:          5031. :            0.            0.             0.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:          -515. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:         -2785. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :         -319.           -0.          -319.:         52642. :            0.       -44912.        -44912.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:            -0. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    8    :
+                                                :     PAV =        288.02  BARSA:
+                                                :     PORV=     99297143.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       448293.          353.        448646.:      95423467. :      1708438.     63733032.      65441471.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        -5707.         -302.         -6009.:        129211. :     -2182343.      -926908.      -3109251.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         0.:            19. :                                        14.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       442638.            0.        442638.:      95552697. :            0.     62332233.      62332233.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :        -3237.            0.         -3237.:         81357. :            0.      -459118.       -459118.:
+ :OUTFLOW TO REGION   2    :            0.            0.             0.:             2. :            0.            0.             0.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:         65083. :            0.            0.             0.:
+ :OUTFLOW TO REGION   4    :            0.            0.             0.:          -109. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :            0.            0.             0.:         12817. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:        -17882. :            0.            0.             0.:
+ :OUTFLOW TO REGION  11    :        -2429.         -302.         -2731.:        -18007. :     -2182343.      -460279.      -2642622.:
+ :OUTFLOW TO REGION  15    :           -7.            0.            -7.:         -2297. :           -0.         -917.          -917.:
+ :OUTFLOW TO REGION  16    :            0.            0.             0.:          8265. :            0.            0.             0.:
+ :OUTFLOW TO REGION  18    :          -35.           -0.           -35.:           -17. :            0.        -6594.         -6594.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    9    :
+                                                :     PAV =        288.09  BARSA:
+                                                :     PORV=      8461267.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      3435149.           -0.       3435149.:       3405038. :           -0.    483737706.     483737706.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        33190.           -0.         33190.:        -21296. :            0.      4673840.       4673840.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         2.:             1. :                                       270.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      3468341.            0.       3468341.:       3383743. :            0.    488411816.     488411816.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :         -365.            0.          -365.:         -3137. :            0.       -51411.        -51411.:
+ :OUTFLOW TO REGION   2    :         6146.           -0.          6146.:            11. :            0.       865461.        865461.:
+ :OUTFLOW TO REGION   5    :           30.            0.            30.:            -1. :            0.         4200.          4200.:
+ :OUTFLOW TO REGION   8    :            0.            0.             0.:        -12817. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :        -5288.           -0.         -5288.:         19474. :            0.      -744639.       -744639.:
+ :OUTFLOW TO REGION  12    :          -32.           -0.           -32.:            -0. :            0.        -4475.         -4475.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:             2. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:            -2. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :       -22705.           -0.        -22705.:        -25503. :            0.     -3197316.      -3197316.:
+ :OUTFLOW TO REGION  19    :        54973.            0.         54973.:           221. :           -0.      7741339.       7741339.:
+ :OUTFLOW TO REGION  20    :          431.           -0.           431.:           454. :            0.        60680.         60680.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   10    :
+                                                :     PAV =        289.10  BARSA:
+                                                :     PORV=     14236567.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      1113114.           -0.       1113114.:      12228773. :           -0.    156748712.     156748712.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :         5731.            0.          5731.:          8470. :           -0.       807099.        807099.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         0.:             1. :                                        60.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      1118846.            0.       1118846.:      12237245. :            0.    157555872.     157555872.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :            0.            0.             0.:          2450. :            0.            0.             0.:
+ :OUTFLOW TO REGION   3    :          640.            0.           640.:           821. :            0.        90135.         90135.:
+ :OUTFLOW TO REGION   4    :            0.            0.             0.:            -2. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:            78. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :            0.            0.             0.:         17882. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :         5288.            0.          5288.:        -19474. :           -0.       744639.        744639.:
+ :OUTFLOW TO REGION  11    :            0.            0.             0.:         -7246. :            0.            0.             0.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:          5846. :            0.            0.             0.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:            12. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:         -2581. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :         -200.            0.          -200.:         -4010. :            0.       -28199.        -28199.:
+ :OUTFLOW TO REGION  18    :            4.            0.             4.:         -2337. :            0.          524.           524.:
+ :OUTFLOW TO REGION  20    :            0.            0.             0.:         17033. :            0.            0.             0.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:            -2. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   11    :
+                                                :     PAV =        290.60  BARSA:
+                                                :     PORV=      7261494.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       387340.        60567.        447907.:       4566683. :    436661795.     73073736.     509735531.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :         1702.          500.          2202.:         36809. :      3579547.       327944.       3907490.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -1.:            -6. :                                     11219.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       382426.        67682.        450108.:       4603487. :    438725604.     74928635.     513654240.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :            0.          199.           199.:             6. :      1431157.            0.       1431157.:
+ :OUTFLOW TO REGION   3    :         -114.           -0.          -114.:          6372. :           -0.       -16350.        -16350.:
+ :OUTFLOW TO REGION   4    :         -232.         -467.          -699.:         -7689. :     -3146622.       -44263.      -3190885.:
+ :OUTFLOW TO REGION   8    :         2429.          302.          2731.:         18007. :      2182343.       460279.       2642622.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:          7246. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:             0. :            0.            0.             0.:
+ :OUTFLOW TO REGION  18    :         -380.          465.            86.:         12867. :      3112668.       -71722.       3040946.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   12    :
+                                                :     PAV =        299.51  BARSA:
+                                                :     PORV=      1639655.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       886477.            0.        886477.:        357496. :           -0.    124833691.     124833691.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :          317.           -0.           317.:            32. :            0.        44691.         44691.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -0.:             0. :                                        -0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       886794.            0.        886794.:        357528. :           -0.    124878382.     124878382.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :           26.           -0.            26.:             0. :            0.         3721.          3721.:
+ :OUTFLOW TO REGION   5    :          220.           -0.           220.:             0. :            0.        31049.         31049.:
+ :OUTFLOW TO REGION   9    :           32.            0.            32.:             0. :            0.         4475.          4475.:
+ :OUTFLOW TO REGION  16    :           17.           -0.            17.:             0. :            0.         2458.          2458.:
+ :OUTFLOW TO REGION  19    :           21.           -0.            21.:            32. :            0.         2988.          2988.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   13    :
+                                                :     PAV =        266.19  BARSA:
+                                                :     PORV=     12433656.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      4843246.           20.       4843266.:       5242071. :       114221.    682062329.     682176550.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :         -831.            0.          -831.:        -64042. :            0.      -117687.       -117687.:
+ :OUTFLOW THROUGH WELLS    :                                    201280.:       -136674. :                                  28204400.:
+ :MATERIAL BALANCE ERROR.  :                                        40.:             6. :                                     -1639.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      5043755.            0.       5043755.:       5041361. :            0.    710261623.     710261623.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :            0.            0.             0.:           -20. :            0.            0.             0.:
+ :OUTFLOW TO REGION   3    :         -407.           -0.          -407.:        -48527. :            0.       -57244.        -57244.:
+ :OUTFLOW TO REGION   5    :            0.            0.             0.:          -171. :            0.            0.             0.:
+ :OUTFLOW TO REGION   6    :         3546.            0.          3546.:          -886. :            0.       498644.        498644.:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:         -5031. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :            0.            0.             0.:            -2. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:         -5846. :            0.            0.             0.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:            -1. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :        -3970.            0.         -3970.:         -3556. :            0.      -559087.       -559087.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   14    :
+                                                :     PAV =        291.69  BARSA:
+                                                :     PORV=     25328539.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :           40.            0.            40.:      24532609. :            0.         5591.          5591.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :          -40.            0.           -40.:         22974. :           -0.        -5580.         -5580.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -0.:            -9. :                                       -11.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :            0.            0.             0.:      24555573. :            0.            0.             0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:            -0. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:           515. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:           -12. :            0.            0.             0.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:             1. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:         -1072. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :          -40.            0.           -40.:         23844. :           -0.        -5580.         -5580.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:          -303. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   15    :
+                                                :     PAV =        289.41  BARSA:
+                                                :     PORV=     89597072.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :        36152.            0.         36152.:      86646083. :           16.      5091067.       5091083.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :          718.           -0.           718.:         96435. :            0.       100916.        100916.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -1.:          -113. :                                       -75.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :        36869.            0.         36869.:      86742405. :            0.      5191924.       5191924.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :            0.            0.             0.:            -0. :            0.            0.             0.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:          2039. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :            7.           -0.             7.:          2297. :            0.          917.           917.:
+ :OUTFLOW TO REGION   9    :            0.            0.             0.:             2. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:          2581. :            0.            0.             0.:
+ :OUTFLOW TO REGION  11    :            0.            0.             0.:            -0. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :            0.            0.             0.:         77480. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:          2767. :            0.            0.             0.:
+ :OUTFLOW TO REGION  18    :          711.           -0.           711.:          9269. :            0.        99999.         99999.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   16    :
+                                                :     PAV =        289.67  BARSA:
+                                                :     PORV=     36879049.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      4243542.           -0.       4243542.:      29774387. :           -0.    597575548.     597575548.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        28154.            0.         28154.:         20077. :            0.      3964576.       3964576.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -7.:           -28. :                                      -949.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      4271689.            0.       4271689.:      29794436. :            0.    601539175.     601539175.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :          -14.           -0.           -14.:         -9960. :            0.        -1946.         -1946.:
+ :OUTFLOW TO REGION   2    :           -4.           -0.            -4.:            -1. :           -0.         -526.          -526.:
+ :OUTFLOW TO REGION   5    :            0.            0.             0.:            -0. :            0.           69.            69.:
+ :OUTFLOW TO REGION   8    :            0.            0.             0.:         -8265. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :        22705.            0.         22705.:         25503. :            0.      3197316.       3197316.:
+ :OUTFLOW TO REGION  12    :          -17.            0.           -17.:            -0. :            0.        -2458.         -2458.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:        -77480. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :        -1879.           -0.         -1879.:         -1713. :            0.      -264602.       -264602.:
+ :OUTFLOW TO REGION  19    :         6344.           -0.          6344.:         30069. :            0.       893300.        893300.:
+ :OUTFLOW TO REGION  20    :         1018.            0.          1018.:         61924. :            0.       143423.        143423.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   17    :
+                                                :     PAV =        289.54  BARSA:
+                                                :     PORV=      5687619.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       356645.           -0.        356645.:       5007968. :           -0.     50222724.      50222724.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :         2079.            0.          2079.:          3704. :           -0.       292801.        292801.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         0.:            -3. :                                         8.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       358724.            0.        358724.:       5011669. :            0.     50515533.      50515533.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:          2785. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :          200.           -0.           200.:          4010. :            0.        28199.         28199.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:          1072. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:         -2767. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :         1879.            0.          1879.:          1713. :            0.       264602.        264602.:
+ :OUTFLOW TO REGION  18    :            0.            0.             0.:          -964. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :            0.            0.             0.:          2238. :            0.            0.             0.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:         -4382. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   18    :
+                                                :     PAV =        291.22  BARSA:
+                                                :     PORV=      3145457.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       702199.         8291.        710490.:       1698535. :     59352188.    132385255.     191737443.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :         1569.         -465.          1103.:         25276. :     -3112633.       625670.      -2486963.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         3.:            -0. :                                      4033.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       703651.         7945.        711595.:       1723811. :     51388228.    137866285.     189254513.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :           90.            0.            90.:             1. :           36.        16842.         16878.:
+ :OUTFLOW TO REGION   3    :         1780.            0.          1780.:         44092. :            0.       631035.        631035.:
+ :OUTFLOW TO REGION   8    :           35.            0.            35.:            17. :            0.         6594.          6594.:
+ :OUTFLOW TO REGION  10    :           -4.           -0.            -4.:          2337. :            0.         -524.          -524.:
+ :OUTFLOW TO REGION  11    :          380.         -465.           -86.:        -12867. :     -3112668.        71722.      -3040946.:
+ :OUTFLOW TO REGION  15    :         -711.            0.          -711.:         -9269. :            0.       -99999.        -99999.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:           964. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   19    :
+                                                :     PAV =        282.78  BARSA:
+                                                :     PORV=      2355763.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      1172333.           -0.       1172333.:        644865. :           -0.    165087954.     165087954.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        29306.           -0.         29306.:        -30079. :            0.      4126939.       4126939.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         2.:             0. :                                       282.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      1201642.            0.       1201642.:        614786. :            0.    169215175.     169215175.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :        90645.           -0.         90645.:           243. :            0.     12764566.      12764566.:
+ :OUTFLOW TO REGION   9    :       -54973.           -0.        -54973.:          -221. :            0.     -7741339.      -7741339.:
+ :OUTFLOW TO REGION  12    :          -21.            0.           -21.:           -32. :            0.        -2988.         -2988.:
+ :OUTFLOW TO REGION  16    :        -6344.            0.         -6344.:        -30069. :            0.      -893300.       -893300.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   20    :
+                                                :     PAV =        282.80  BARSA:
+                                                :     PORV=     18527269.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      6824088.           -0.       6824088.:       8411604. :           -0.    960968147.     960968147.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       -19004.           -0.        -19004.:       -199948. :           -0.     -2676096.      -2676096.:
+ :OUTFLOW THROUGH WELLS    :                                    262943.:        -75523. :                                  37027649.:
+ :MATERIAL BALANCE ERROR.  :                                         2.:            17. :                                       258.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      7068030.            0.       7068030.:       8136150. :           -0.    995319957.     995319957.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :       -14339.            0.        -14339.:         -2032. :            0.     -2019232.      -2019232.:
+ :OUTFLOW TO REGION   3    :         -114.           -0.          -114.:        -17936. :           -0.       -16077.        -16077.:
+ :OUTFLOW TO REGION   5    :        -7430.            0.         -7430.:            -0. :            0.     -1046262.      -1046262.:
+ :OUTFLOW TO REGION   6    :            0.            0.             0.:             3. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :          319.            0.           319.:        -52642. :            0.        44912.         44912.:
+ :OUTFLOW TO REGION   9    :         -431.            0.          -431.:          -454. :            0.       -60680.        -60680.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:        -17033. :            0.            0.             0.:
+ :OUTFLOW TO REGION  13    :         3970.           -0.          3970.:          3556. :            0.       559087.        559087.:
+ :OUTFLOW TO REGION  14    :           40.           -0.            40.:        -23844. :            0.         5580.          5580.:
+ :OUTFLOW TO REGION  16    :        -1018.           -0.         -1018.:        -61924. :            0.      -143423.       -143423.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:         -2238. :            0.            0.             0.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:        -25403. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   21    :
+                                                :     PAV =        301.29  BARSA:
+                                                :     PORV=     28314973.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :            0.            0.             0.:      27407721. :            0.            0.             0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :            0.            0.             0.:         30090. :            0.            0.             0.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         0.:          -109. :                                         0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :            0.            0.             0.:      27437701. :            0.            0.             0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:             0. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:             2. :            0.            0.             0.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:           303. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:          4382. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :            0.            0.             0.:         25403. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                     ===================================
+                                                     :  FIPNUM OIL RECOVERY FACTORS    :
+ :---------:-----------------------------:---------------------------------------------:--------------------------------------------:
+ :         :                             : RATIO OF       RATIO OF       RATIO OF      : RATIO OF       RATIO OF       RATIO OF     :
+ : REGION  : MOBILE OIIP    MOBILE OIIP  : DISPLACED OIL  DISPLACED OIL  DISPLACED OIL : WELL FLOW      WELL FLOW      WELL FLOW    :
+ :         : (W.R.T WATER)  (W.R.T GAS)  : TO INITIAL     TO INITIAL     TO INITIAL    : TO INITIAL     TO INITIAL     TO INITIAL   :
+ :         :                             : OIP            MOBILE OIL     MOBILE OIL    : OIP            MOBILE OIL     MOBILE OIL   :
+ :         :                             :                (WATER)        (GAS)         :                (WATER)        (GAS)        :
+ :---------:-----------------------------:---------------------------------------------:--------------------------------------------:
+ :   FIELD :    3.467E+07      3.799E+07 :   0.02420        0.03185       0.02907      :   0.02419        0.03185        0.02907    :
+ :       1 :    1.464E+06      1.608E+06 :   0.00158        0.00212       0.00193      :         0              0              0    :
+ :       2 :    5.735E+06      6.204E+06 :   0.01607        0.02077       0.01920      :         0              0              0    :
+ :       3 :    1.865E+06      2.037E+06 :   0.07830        0.10338       0.09468      :   0.16134        0.21302        0.19508    :
+ :       4 :    1.659E+05      2.936E+05 :   0.00670        0.01380       0.00780      :         0              0              0    :
+ :       5 :    7.773E+05      8.642E+05 :   0.00662        0.00898       0.00807      :         0              0              0    :
+ :       6 :    5.619E+06      6.139E+06 :   0.03280        0.04284       0.03921      :   0.03307        0.04320        0.03954    :
+ :       7 :    0.000E+00      0.000E+00 :                                             :                                            :
+ :       8 :    2.984E+05      3.384E+05 :  -0.01358       -0.02014      -0.01776      :         0              0              0    :
+ :       9 :    2.613E+06      2.859E+06 :   0.00957        0.01270       0.01161      :         0              0              0    :
+ :      10 :    8.101E+05      9.000E+05 :   0.00512        0.00708       0.00637      :         0              0              0    :
+ :      11 :    2.426E+05      3.463E+05 :   0.00489        0.00907       0.00636      :         0              0              0    :
+ :      12 :    6.806E+05      7.415E+05 :   0.00036        0.00047       0.00043      :         0              0              0    :
+ :      13 :    3.885E+06      4.220E+06 :   0.03975        0.05161       0.04750      :   0.03991        0.05181        0.04769    :
+ :      14 :    0.000E+00      0.000E+00 :                                             :                                            :
+ :      15 :    2.836E+04      3.076E+04 :   0.01945        0.02528       0.02331      :         0              0              0    :
+ :      16 :    3.251E+06      3.546E+06 :   0.00659        0.00866       0.00794      :         0              0              0    :
+ :      17 :    2.645E+05      2.934E+05 :   0.00580        0.00786       0.00709      :         0              0              0    :
+ :      18 :    5.443E+05      5.977E+05 :   0.00155        0.00203       0.00185      :         0              0              0    :
+ :      19 :    9.198E+05      1.002E+06 :   0.02439        0.03186       0.02924      :         0              0              0    :
+ :      20 :    5.505E+06      5.963E+06 :   0.03451        0.04431       0.04091      :   0.03720        0.04777        0.04410    :
+ :      21 :    0.000E+00      0.000E+00 :                                             :                                            :
+ ====================================================================================================================================
+
+ @--MESSAGE  AT TIME      181.0   DAYS    ( 1-JLY-2018):
+ @           GRAPHICS ONLY RESTART FILE WRITTEN   REPORT    16               
+ @           RESTART INCLUDES INTERBLOCK FLOWS                               
+ @                            BUBBLE AND DEW POINT PRESSURES                 
+ @                            PHASE RESERVOIR DENSITIES                      
+ @                            SATURATED GOR                                  
+ @                            SATURATED OGR                                  
+   333 READING WCONHIST
+   334 READING RPTSCHED
+   335 READING RPTRST  
+
+ @--COMMENT  AT TIME      181.0   DAYS    ( 1-JLY-2018):
+ @           RESTART OUTPUT HAS BEEN TURNED OFF WITH BASIC=0                 
+ @           ALL OTHER MNEMONICS WILL BE IGNORED                             
+   336 READING DATES   
+1                             **********************************************************************  19
+  SIMULATE AT    181.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  16     1 JLY 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   48 TIME=    182.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (2-JLY-2018)       
+  PAV=   280.2  BARSA  WCT=0.002 GOR=   137.90  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   49 TIME=    183.00  DAYS (    +1.0  DAYS REPT  1 ITS) (3-JLY-2018)       
+  PAV=   280.2  BARSA  WCT=0.002 GOR=   138.02  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   337 READING WCONHIST
+   338 READING WRFTPLT 
+   339 READING DATES   
+1                             **********************************************************************  20
+  SIMULATE AT    183.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  17     3 JLY 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   50 TIME=    184.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (4-JLY-2018)       
+  PAV=   280.2  BARSA  WCT=0.002 GOR=   137.88  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   51 TIME=    187.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (7-JLY-2018)       
+  PAV=   280.2  BARSA  WCT=0.002 GOR=   138.20  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   52 TIME=    193.00  DAYS (    +6.0  DAYS REPT  4 ITS) (13-JLY-2018)      
+  PAV=   280.2  BARSA  WCT=0.003 GOR=   138.56  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   340 READING WELSPECS
+   341 READING COMPORD 
+   342 READING COMPDAT 
+   343 READING COMPLUMP
+   344 READING WCONHIST
+
+ @--MESSAGE  AT TIME      193.0   DAYS    (13-JLY-2018):
+ @           OPENING WELL A3       AT TIME    193.00   DAYS                  
+ @           CONTROLLED BY RESERVOIR FLUID VOLUME RATE                       
+   345 READING WELTARG 
+   346 READING DATES   
+1                             **********************************************************************  21
+  SIMULATE AT    193.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  18    13 JLY 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   53 TIME=    194.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (14-JLY-2018)      
+  PAV=   279.9  BARSA  WCT=0.002 GOR=   139.20  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   54 TIME=    197.00  DAYS (    +3.0  DAYS MAXF  3 ITS) (17-JLY-2018)      
+  PAV=   279.3  BARSA  WCT=0.002 GOR=   139.57  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   55 TIME=    204.50  DAYS (    +7.5  DAYS HALF  4 ITS) (24-JLY-2018)      
+  PAV=   278.2  BARSA  WCT=0.004 GOR=   139.23  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   56 TIME=    212.00  DAYS (    +7.5  DAYS REPT  4 ITS) (1-AUG-2018)       
+  PAV=   277.4  BARSA  WCT=0.006 GOR=   138.25  SM3/SM3 WGR=   0.0000  SM3/SM3   
+   347 READING WCONHIST
+   348 READING DATES   
+1                             **********************************************************************  22
+  SIMULATE AT    212.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  19     1 AUG 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   57 TIME=    213.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (2-AUG-2018)       
+  PAV=   277.3  BARSA  WCT=0.006 GOR=   137.49  SM3/SM3 WGR=   0.0000  SM3/SM3   
+
+ STEP   58 TIME=    216.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-AUG-2018)       
+  PAV=   277.0  BARSA  WCT=0.007 GOR=   137.24  SM3/SM3 WGR=   0.0001  SM3/SM3   
+
+ STEP   59 TIME=    225.00  DAYS (    +9.0  DAYS MAXF  4 ITS) (14-AUG-2018)      
+  PAV=   276.2  BARSA  WCT=0.010 GOR=   136.65  SM3/SM3 WGR=   0.0001  SM3/SM3   
+
+ STEP   60 TIME=    236.00  DAYS (   +11.0  DAYS REPT  4 ITS) (25-AUG-2018)      
+  PAV=   275.3  BARSA  WCT=0.016 GOR=   136.53  SM3/SM3 WGR=   0.0001  SM3/SM3   
+   349 READING WCONHIST
+   350 READING DATES   
+1                             **********************************************************************  23
+  SIMULATE AT    236.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  20    25 AUG 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   61 TIME=    237.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (26-AUG-2018)      
+  PAV=   275.2  BARSA  WCT=0.015 GOR=   137.18  SM3/SM3 WGR=   0.0001  SM3/SM3   
+
+ STEP   62 TIME=    240.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (29-AUG-2018)      
+  PAV=   275.0  BARSA  WCT=0.017 GOR=   136.68  SM3/SM3 WGR=   0.0001  SM3/SM3   
+
+ STEP   63 TIME=    243.00  DAYS (    +3.0  DAYS REPT  3 ITS) (1-SEP-2018)       
+  PAV=   274.7  BARSA  WCT=0.018 GOR=   136.40  SM3/SM3 WGR=   0.0001  SM3/SM3   
+   351 READING WCONHIST
+   352 READING DATES   
+1                             **********************************************************************  24
+  SIMULATE AT    243.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  21     1 SEP 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   64 TIME=    244.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (2-SEP-2018)       
+  PAV=   274.6  BARSA  WCT=0.018 GOR=   137.12  SM3/SM3 WGR=   0.0001  SM3/SM3   
+
+ STEP   65 TIME=    247.00  DAYS (    +3.0  DAYS MAXF  3 ITS) (5-SEP-2018)       
+  PAV=   274.3  BARSA  WCT=0.020 GOR=   136.56  SM3/SM3 WGR=   0.0001  SM3/SM3   
+
+ STEP   66 TIME=    254.00  DAYS (    +7.0  DAYS REPT  3 ITS) (12-SEP-2018)      
+  PAV=   273.7  BARSA  WCT=0.024 GOR=   138.28  SM3/SM3 WGR=   0.0002  SM3/SM3   
+   353 READING WCONHIST
+   354 READING WRFTPLT 
+   355 READING DATES   
+1                             **********************************************************************  25
+  SIMULATE AT    254.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  22    12 SEP 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   67 TIME=    255.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (13-SEP-2018)      
+  PAV=   273.6  BARSA  WCT=0.024 GOR=   139.78  SM3/SM3 WGR=   0.0002  SM3/SM3   
+
+ STEP   68 TIME=    256.00  DAYS (    +1.0  DAYS REPT  1 ITS) (14-SEP-2018)      
+  PAV=   273.5  BARSA  WCT=0.024 GOR=   140.60  SM3/SM3 WGR=   0.0002  SM3/SM3   
+   356 READING WCONHIST
+   357 READING DATES   
+1                             **********************************************************************  26
+  SIMULATE AT    256.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  23    14 SEP 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   69 TIME=    257.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (15-SEP-2018)      
+  PAV=   273.4  BARSA  WCT=0.025 GOR=   141.51  SM3/SM3 WGR=   0.0002  SM3/SM3   
+
+ STEP   70 TIME=    260.00  DAYS (    +3.0  DAYS MAXF  5 ITS) (18-SEP-2018)      
+  PAV=   273.1  BARSA  WCT=0.026 GOR=   142.36  SM3/SM3 WGR=   0.0002  SM3/SM3   
+
+ STEP   71 TIME=    264.00  DAYS (    +4.0  DAYS REPT  4 ITS) (22-SEP-2018)      
+  PAV=   272.8  BARSA  WCT=0.029 GOR=   143.13  SM3/SM3 WGR=   0.0002  SM3/SM3   
+   358 READING WELSPECS
+   359 READING COMPORD 
+   360 READING COMPDAT 
+   361 READING COMPLUMP
+   362 READING WELSEGS 
+   363 READING WSEGVALV
+   364 READING COMPSEGS
+   365 READING WCONHIST
+
+ @--MESSAGE  AT TIME      264.0   DAYS    (22-SEP-2018):
+ @           OPENING WELL A4       AT TIME    264.00   DAYS                  
+ @           CONTROLLED BY RESERVOIR FLUID VOLUME RATE                       
+   366 READING WELTARG 
+   367 READING DATES   
+1                             **********************************************************************  27
+  SIMULATE AT    264.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  24    22 SEP 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   72 TIME=    265.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (23-SEP-2018)      
+  PAV=   272.4  BARSA  WCT=0.023 GOR=   142.77  SM3/SM3 WGR=   0.0002  SM3/SM3   
+
+ STEP   73 TIME=    268.00  DAYS (    +3.0  DAYS MAXF  4 ITS) (26-SEP-2018)      
+  PAV=   271.6  BARSA  WCT=0.025 GOR=   143.42  SM3/SM3 WGR=   0.0002  SM3/SM3   
+
+ STEP   74 TIME=    273.00  DAYS (    +5.0  DAYS REPT  3 ITS) (1-OCT-2018)       
+  PAV=   270.5  BARSA  WCT=0.027 GOR=   144.49  SM3/SM3 WGR=   0.0002  SM3/SM3   
+   368 READING WCONHIST
+   369 READING DATES   
+1                             **********************************************************************  28
+  SIMULATE AT    273.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  25     1 OCT 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   75 TIME=    274.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (2-OCT-2018)       
+  PAV=   270.3  BARSA  WCT=0.027 GOR=   144.80  SM3/SM3 WGR=   0.0002  SM3/SM3   
+
+ STEP   76 TIME=    277.00  DAYS (    +3.0  DAYS REPT  2 ITS) (5-OCT-2018)       
+  PAV=   269.6  BARSA  WCT=0.029 GOR=   145.51  SM3/SM3 WGR=   0.0002  SM3/SM3   
+   370 READING WCONHIST
+   371 READING DATES   
+1                             **********************************************************************  29
+  SIMULATE AT    277.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  26     5 OCT 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   77 TIME=    278.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (6-OCT-2018)       
+  PAV=   269.4  BARSA  WCT=0.029 GOR=   144.07  SM3/SM3 WGR=   0.0002  SM3/SM3   
+
+ STEP   78 TIME=    281.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (9-OCT-2018)       
+  PAV=   268.9  BARSA  WCT=0.031 GOR=   143.93  SM3/SM3 WGR=   0.0002  SM3/SM3   
+
+ STEP   79 TIME=    290.00  DAYS (    +9.0  DAYS MAXF  5 ITS) (18-OCT-2018)      
+  PAV=   267.5  BARSA  WCT=0.035 GOR=   145.27  SM3/SM3 WGR=   0.0003  SM3/SM3   
+
+ STEP   80 TIME=    297.00  DAYS (    +7.0  DAYS HALF  4 ITS) (25-OCT-2018)      
+  PAV=   266.4  BARSA  WCT=0.039 GOR=   146.63  SM3/SM3 WGR=   0.0003  SM3/SM3   
+
+ STEP   81 TIME=    304.00  DAYS (    +7.0  DAYS REPT  3 ITS) (1-NOV-2018)       
+  PAV=   265.5  BARSA  WCT=0.043 GOR=   148.38  SM3/SM3 WGR=   0.0003  SM3/SM3   
+   372 READING WCONHIST
+   373 READING DATES   
+1                             **********************************************************************  30
+  SIMULATE AT    304.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  27     1 NOV 2018   *  RUN                                                                   * RUN AT 09:07 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   82 TIME=    305.00  DAYS (    +1.0  DAYS MAXW  3 ITS) (2-NOV-2018)       
+  PAV=   265.3  BARSA  WCT=0.046 GOR=   141.84  SM3/SM3 WGR=   0.0003  SM3/SM3   
+
+ STEP   83 TIME=    307.50  DAYS (    +2.5  DAYS HALF  2 ITS) (4-NOV-2018)       
+  PAV=   265.1  BARSA  WCT=0.048 GOR=   140.22  SM3/SM3 WGR=   0.0004  SM3/SM3   
+
+ STEP   84 TIME=    310.00  DAYS (    +2.5  DAYS REPT  2 ITS) (7-NOV-2018)       
+  PAV=   264.8  BARSA  WCT=0.049 GOR=   139.92  SM3/SM3 WGR=   0.0004  SM3/SM3   
+   374 READING WCONHIST
+   375 READING WRFTPLT 
+   376 READING DATES   
+1                             **********************************************************************  31
+  SIMULATE AT    310.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  28     7 NOV 2018   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   85 TIME=    311.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (8-NOV-2018)       
+  PAV=   264.7  BARSA  WCT=0.051 GOR=   138.23  SM3/SM3 WGR=   0.0004  SM3/SM3   
+
+ STEP   86 TIME=    314.00  DAYS (    +3.0  DAYS MAXF  3 ITS) (11-NOV-2018)      
+  PAV=   264.4  BARSA  WCT=0.052 GOR=   138.75  SM3/SM3 WGR=   0.0004  SM3/SM3   
+
+ STEP   87 TIME=    320.00  DAYS (    +6.0  DAYS REPT  3 ITS) (17-NOV-2018)      
+  PAV=   263.8  BARSA  WCT=0.055 GOR=   139.92  SM3/SM3 WGR=   0.0004  SM3/SM3   
+   377 READING WELSPECS
+   378 READING COMPORD 
+   379 READING COMPDAT 
+   380 READING COMPLUMP
+   381 READING WCONHIST
+   382 READING WCONINJH
+
+ @--MESSAGE  AT TIME      320.0   DAYS    (17-NOV-2018):
+ @           OPENING WELL A6       AT TIME    320.00   DAYS                  
+ @           CONTROLLED BY WATER RATE                                        
+   383 READING DATES   
+1                             **********************************************************************  32
+  SIMULATE AT    320.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  29    17 NOV 2018   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   88 TIME=    321.00  DAYS (    +1.0  DAYS MAXW  3 ITS) (18-NOV-2018)      
+  PAV=   263.8  BARSA  WCT=0.057 GOR=   138.40  SM3/SM3 WGR=   0.0004  SM3/SM3   
+
+ STEP   89 TIME=    324.00  DAYS (    +3.0  DAYS MAXF  3 ITS) (21-NOV-2018)      
+  PAV=   263.8  BARSA  WCT=0.058 GOR=   138.64  SM3/SM3 WGR=   0.0004  SM3/SM3   
+
+ STEP   90 TIME=    329.00  DAYS (    +5.0  DAYS HALF  5 ITS) (26-NOV-2018)      
+  PAV=   263.7  BARSA  WCT=0.061 GOR=   139.04  SM3/SM3 WGR=   0.0005  SM3/SM3   
+
+ STEP   91 TIME=    334.00  DAYS (    +5.0  DAYS REPT  3 ITS) (1-DEC-2018)       
+  PAV=   263.6  BARSA  WCT=0.063 GOR=   139.53  SM3/SM3 WGR=   0.0005  SM3/SM3   
+   384 READING WCONHIST
+   385 READING DATES   
+1                             **********************************************************************  33
+  SIMULATE AT    334.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  30     1 DEC 2018   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   92 TIME=    335.00  DAYS (    +1.0  DAYS MAXW  3 ITS) (2-DEC-2018)       
+  PAV=   263.6  BARSA  WCT=0.064 GOR=   139.48  SM3/SM3 WGR=   0.0005  SM3/SM3   
+
+ STEP   93 TIME=    337.50  DAYS (    +2.5  DAYS HALF  2 ITS) (4-DEC-2018)       
+  PAV=   263.6  BARSA  WCT=0.066 GOR=   139.71  SM3/SM3 WGR=   0.0005  SM3/SM3   
+
+ STEP   94 TIME=    340.00  DAYS (    +2.5  DAYS REPT  3 ITS) (7-DEC-2018)       
+  PAV=   263.5  BARSA  WCT=0.067 GOR=   139.92  SM3/SM3 WGR=   0.0005  SM3/SM3   
+   386 READING WCONHIST
+   387 READING DATES   
+1                             **********************************************************************  34
+  SIMULATE AT    340.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  31     7 DEC 2018   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   95 TIME=    341.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (8-DEC-2018)       
+  PAV=   263.5  BARSA  WCT=0.068 GOR=   140.03  SM3/SM3 WGR=   0.0005  SM3/SM3   
+
+ STEP   96 TIME=    344.00  DAYS (    +3.0  DAYS MAXF  3 ITS) (11-DEC-2018)      
+  PAV=   263.5  BARSA  WCT=0.069 GOR=   140.22  SM3/SM3 WGR=   0.0005  SM3/SM3   
+
+ STEP   97 TIME=    348.00  DAYS (    +4.0  DAYS REPT  2 ITS) (15-DEC-2018)      
+  PAV=   263.4  BARSA  WCT=0.072 GOR=   140.43  SM3/SM3 WGR=   0.0005  SM3/SM3   
+   388 READING WCONHIST
+   389 READING DATES   
+1                             **********************************************************************  35
+  SIMULATE AT    348.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  32    15 DEC 2018   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP   98 TIME=    349.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (16-DEC-2018)      
+  PAV=   263.4  BARSA  WCT=0.072 GOR=   140.54  SM3/SM3 WGR=   0.0006  SM3/SM3   
+
+ STEP   99 TIME=    350.00  DAYS (    +1.0  DAYS REPT  2 ITS) (17-DEC-2018)      
+  PAV=   263.3  BARSA  WCT=0.073 GOR=   140.63  SM3/SM3 WGR=   0.0006  SM3/SM3   
+   390 READING WTRACER 
+   391 READING WCONHIST
+   392 READING DATES   
+1                             **********************************************************************  36
+  SIMULATE AT    350.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  33    17 DEC 2018   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  100 TIME=    351.00  DAYS (    +1.0  DAYS REPT  1 ITS) (18-DEC-2018)      
+  PAV=   263.3  BARSA  WCT=0.073 GOR=   140.70  SM3/SM3 WGR=   0.0006  SM3/SM3   
+   393 READING WTRACER 
+   394 READING WCONHIST
+   395 READING DATES   
+1                             **********************************************************************  37
+  SIMULATE AT    351.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  34    18 DEC 2018   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  101 TIME=    352.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (19-DEC-2018)      
+  PAV=   263.3  BARSA  WCT=0.074 GOR=   140.79  SM3/SM3 WGR=   0.0006  SM3/SM3   
+
+ STEP  102 TIME=    355.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (22-DEC-2018)      
+  PAV=   263.3  BARSA  WCT=0.076 GOR=   140.90  SM3/SM3 WGR=   0.0006  SM3/SM3   
+
+ STEP  103 TIME=    361.00  DAYS (    +6.0  DAYS REPT  4 ITS) (28-DEC-2018)      
+  PAV=   263.2  BARSA  WCT=0.079 GOR=   141.23  SM3/SM3 WGR=   0.0006  SM3/SM3   
+   396 READING WCONHIST
+   397 READING DATES   
+1                             **********************************************************************  38
+  SIMULATE AT    361.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  35    28 DEC 2018   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  104 TIME=    362.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (29-DEC-2018)      
+  PAV=   263.1  BARSA  WCT=0.080 GOR=   141.29  SM3/SM3 WGR=   0.0006  SM3/SM3   
+
+ STEP  105 TIME=    365.00  DAYS (    +3.0  DAYS REPT  3 ITS) (1-JAN-2019)       
+  PAV=   263.1  BARSA  WCT=0.081 GOR=   141.49  SM3/SM3 WGR=   0.0006  SM3/SM3   
+   398 READING WCONHIST
+   399 READING DATES   
+1                             **********************************************************************  39
+  SIMULATE AT    365.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  36     1 JAN 2019   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  106 TIME=    366.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (2-JAN-2019)       
+  PAV=   263.1  BARSA  WCT=0.082 GOR=   141.45  SM3/SM3 WGR=   0.0006  SM3/SM3   
+
+ STEP  107 TIME=    369.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-JAN-2019)       
+  PAV=   263.0  BARSA  WCT=0.084 GOR=   141.56  SM3/SM3 WGR=   0.0006  SM3/SM3   
+
+ STEP  108 TIME=    378.00  DAYS (    +9.0  DAYS MAXF  5 ITS) (14-JAN-2019)      
+  PAV=   262.9  BARSA  WCT=0.089 GOR=   141.97  SM3/SM3 WGR=   0.0007  SM3/SM3   
+
+ STEP  109 TIME=    396.00  DAYS (   +18.0  DAYS REPT  6 ITS) (1-FEB-2019)       
+  PAV=   262.6  BARSA  WCT=0.097 GOR=   142.43  SM3/SM3 WGR=   0.0008  SM3/SM3   
+   400 READING WCONHIST
+   401 READING DATES   
+1                             **********************************************************************  40
+  SIMULATE AT    396.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  37     1 FEB 2019   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  110 TIME=    397.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (2-FEB-2019)       
+  PAV=   262.6  BARSA  WCT=0.098 GOR=   142.32  SM3/SM3 WGR=   0.0008  SM3/SM3   
+
+ STEP  111 TIME=    400.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-FEB-2019)       
+  PAV=   262.5  BARSA  WCT=0.099 GOR=   142.36  SM3/SM3 WGR=   0.0008  SM3/SM3   
+
+ STEP  112 TIME=    404.00  DAYS (    +4.0  DAYS REPT  4 ITS) (9-FEB-2019)       
+  PAV=   262.4  BARSA  WCT=0.101 GOR=   142.41  SM3/SM3 WGR=   0.0008  SM3/SM3   
+   402 READING WCONHIST
+   403 READING DATES   
+1                             **********************************************************************  41
+  SIMULATE AT    404.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  38     9 FEB 2019   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  113 TIME=    405.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (10-FEB-2019)      
+  PAV=   262.4  BARSA  WCT=0.102 GOR=   142.36  SM3/SM3 WGR=   0.0008  SM3/SM3   
+
+ STEP  114 TIME=    408.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (13-FEB-2019)      
+  PAV=   262.4  BARSA  WCT=0.103 GOR=   142.36  SM3/SM3 WGR=   0.0008  SM3/SM3   
+
+ STEP  115 TIME=    416.00  DAYS (    +8.0  DAYS HALF  5 ITS) (21-FEB-2019)      
+  PAV=   262.3  BARSA  WCT=0.107 GOR=   142.40  SM3/SM3 WGR=   0.0008  SM3/SM3   
+
+ STEP  116 TIME=    424.00  DAYS (    +8.0  DAYS REPT  3 ITS) (1-MAR-2019)       
+  PAV=   262.1  BARSA  WCT=0.110 GOR=   142.43  SM3/SM3 WGR=   0.0009  SM3/SM3   
+   404 READING WCONHIST
+   405 READING DATES   
+1                             **********************************************************************  42
+  SIMULATE AT    424.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  39     1 MAR 2019   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  117 TIME=    425.00  DAYS (    +1.0  DAYS MAXW  3 ITS) (2-MAR-2019)       
+  PAV=   262.1  BARSA  WCT=0.111 GOR=   142.42  SM3/SM3 WGR=   0.0009  SM3/SM3   
+
+ STEP  118 TIME=    428.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-MAR-2019)       
+  PAV=   262.1  BARSA  WCT=0.112 GOR=   142.49  SM3/SM3 WGR=   0.0009  SM3/SM3   
+
+ STEP  119 TIME=    432.00  DAYS (    +4.0  DAYS REPT  2 ITS) (9-MAR-2019)       
+  PAV=   262.0  BARSA  WCT=0.113 GOR=   142.53  SM3/SM3 WGR=   0.0009  SM3/SM3   
+   406 READING WCONHIST
+   407 READING DATES   
+1                             **********************************************************************  43
+  SIMULATE AT    432.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  40     9 MAR 2019   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  120 TIME=    433.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (10-MAR-2019)      
+  PAV=   262.0  BARSA  WCT=0.114 GOR=   142.54  SM3/SM3 WGR=   0.0009  SM3/SM3   
+
+ STEP  121 TIME=    436.00  DAYS (    +3.0  DAYS MAXF  4 ITS) (13-MAR-2019)      
+  PAV=   262.0  BARSA  WCT=0.115 GOR=   142.59  SM3/SM3 WGR=   0.0009  SM3/SM3   
+
+ STEP  122 TIME=    445.00  DAYS (    +9.0  DAYS REPT  3 ITS) (22-MAR-2019)      
+  PAV=   261.8  BARSA  WCT=0.119 GOR=   142.66  SM3/SM3 WGR=   0.0009  SM3/SM3   
+   408 READING WCONHIST
+   409 READING DATES   
+1                             **********************************************************************  44
+  SIMULATE AT    445.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  41    22 MAR 2019   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  123 TIME=    446.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (23-MAR-2019)      
+  PAV=   261.8  BARSA  WCT=0.119 GOR=   142.64  SM3/SM3 WGR=   0.0009  SM3/SM3   
+
+ STEP  124 TIME=    449.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (26-MAR-2019)      
+  PAV=   261.8  BARSA  WCT=0.120 GOR=   142.66  SM3/SM3 WGR=   0.0010  SM3/SM3   
+
+ STEP  125 TIME=    455.00  DAYS (    +6.0  DAYS REPT  2 ITS) (1-APR-2019)       
+  PAV=   261.7  BARSA  WCT=0.122 GOR=   142.70  SM3/SM3 WGR=   0.0010  SM3/SM3   
+   410 READING WCONHIST
+   411 READING DATES   
+1                             **********************************************************************  45
+  SIMULATE AT    455.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  42     1 APR 2019   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  126 TIME=    456.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (2-APR-2019)       
+  PAV=   261.7  BARSA  WCT=0.123 GOR=   142.75  SM3/SM3 WGR=   0.0010  SM3/SM3   
+
+ STEP  127 TIME=    459.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-APR-2019)       
+  PAV=   261.7  BARSA  WCT=0.124 GOR=   142.76  SM3/SM3 WGR=   0.0010  SM3/SM3   
+
+ STEP  128 TIME=    468.00  DAYS (    +9.0  DAYS MAXF  4 ITS) (14-APR-2019)      
+  PAV=   261.5  BARSA  WCT=0.127 GOR=   142.81  SM3/SM3 WGR=   0.0010  SM3/SM3   
+
+ STEP  129 TIME=    485.00  DAYS (   +17.0  DAYS REPT  4 ITS) (1-MAY-2019)       
+  PAV=   261.3  BARSA  WCT=0.133 GOR=   143.18  SM3/SM3 WGR=   0.0011  SM3/SM3   
+   412 READING WCONHIST
+   413 READING WCONINJH
+   414 READING DATES   
+1                             **********************************************************************  46
+  SIMULATE AT    485.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  43     1 MAY 2019   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  130 TIME=    486.00  DAYS (    +1.0  DAYS MAXW  5 ITS) (2-MAY-2019)       
+  PAV=   261.4  BARSA  WCT= 0.00 GOR= 0.00000   SM3/SM3 WGR= 0.00000   SM3/SM3   
+
+ STEP  131 TIME=    487.00  DAYS (    +1.0  DAYS HALF  3 ITS) (3-MAY-2019)       
+  PAV=   261.4  BARSA  WCT= 0.00 GOR= 0.00000   SM3/SM3 WGR= 0.00000   SM3/SM3   
+
+ STEP  132 TIME=    488.00  DAYS (    +1.0  DAYS REPT  2 ITS) (4-MAY-2019)       
+  PAV=   261.5  BARSA  WCT= 0.00 GOR= 0.00000   SM3/SM3 WGR= 0.00000   SM3/SM3   
+   415 READING DATES   
+1                             **********************************************************************  47
+  SIMULATE AT    488.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  44     4 MAY 2019   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  133 TIME=    489.00  DAYS (    +1.0  DAYS REPT  2 ITS) (5-MAY-2019)       
+  PAV=   261.5  BARSA  WCT= 0.00 GOR= 0.00000   SM3/SM3 WGR= 0.00000   SM3/SM3   
+   416 READING WCONHIST
+   417 READING WCONINJH
+   418 READING DATES   
+1                             **********************************************************************  48
+  SIMULATE AT    489.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  45     5 MAY 2019   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  134 TIME=    490.00  DAYS (    +1.0  DAYS MAXW  3 ITS) (6-MAY-2019)       
+  PAV=   261.5  BARSA  WCT=0.131 GOR=   142.05  SM3/SM3 WGR=   0.0011  SM3/SM3   
+
+ STEP  135 TIME=    491.71  DAYS (    +1.7  DAYS TRNC  2 ITS) (7-MAY-2019)       
+  PAV=   261.4  BARSA  WCT=0.134 GOR=   141.78  SM3/SM3 WGR=   0.0011  SM3/SM3   
+
+ STEP  136 TIME=    495.13  DAYS (    +3.4  DAYS TRNC  3 ITS) (11-MAY-2019)      
+  PAV=   261.4  BARSA  WCT=0.136 GOR=   142.49  SM3/SM3 WGR=   0.0011  SM3/SM3   
+
+ STEP  137 TIME=    501.56  DAYS (    +6.4  DAYS HALF  3 ITS) (17-MAY-2019)      
+  PAV=   261.3  BARSA  WCT=0.138 GOR=   143.68  SM3/SM3 WGR=   0.0011  SM3/SM3   
+
+ STEP  138 TIME=    508.00  DAYS (    +6.4  DAYS REPT  3 ITS) (24-MAY-2019)      
+  PAV=   261.2  BARSA  WCT=0.140 GOR=   144.38  SM3/SM3 WGR=   0.0011  SM3/SM3   
+   419 READING WCONHIST
+   420 READING DATES   
+1                             **********************************************************************  49
+  SIMULATE AT    508.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  46    24 MAY 2019   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  139 TIME=    509.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (25-MAY-2019)      
+  PAV=   261.2  BARSA  WCT=0.139 GOR=   144.04  SM3/SM3 WGR=   0.0011  SM3/SM3   
+
+ STEP  140 TIME=    512.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (28-MAY-2019)      
+  PAV=   261.1  BARSA  WCT=0.140 GOR=   144.29  SM3/SM3 WGR=   0.0011  SM3/SM3   
+
+ STEP  141 TIME=    516.00  DAYS (    +4.0  DAYS REPT  2 ITS) (1-JUN-2019)       
+  PAV=   261.0  BARSA  WCT=0.141 GOR=   144.49  SM3/SM3 WGR=   0.0011  SM3/SM3   
+   421 READING WCONHIST
+   422 READING DATES   
+1                             **********************************************************************  50
+  SIMULATE AT    516.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  47     1 JUN 2019   *  RUN                                                                   * RUN AT 09:08 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  142 TIME=    517.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (2-JUN-2019)       
+  PAV=   261.0  BARSA  WCT=0.141 GOR=   144.56  SM3/SM3 WGR=   0.0011  SM3/SM3   
+
+ STEP  143 TIME=    520.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-JUN-2019)       
+  PAV=   260.9  BARSA  WCT=0.142 GOR=   144.70  SM3/SM3 WGR=   0.0011  SM3/SM3   
+
+ STEP  144 TIME=    529.00  DAYS (    +9.0  DAYS REPT  3 ITS) (14-JUN-2019)      
+  PAV=   260.8  BARSA  WCT=0.147 GOR=   145.03  SM3/SM3 WGR=   0.0012  SM3/SM3   
+   423 READING WCONHIST
+   424 READING DATES   
+1                             **********************************************************************  51
+  SIMULATE AT    529.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  48    14 JUN 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  145 TIME=    530.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (15-JUN-2019)      
+  PAV=   260.8  BARSA  WCT=0.147 GOR=   145.13  SM3/SM3 WGR=   0.0012  SM3/SM3   
+
+ STEP  146 TIME=    533.00  DAYS (    +3.0  DAYS MAXF  5 ITS) (18-JUN-2019)      
+  PAV=   260.7  BARSA  WCT=0.148 GOR=   145.26  SM3/SM3 WGR=   0.0012  SM3/SM3   
+
+ STEP  147 TIME=    539.00  DAYS (    +6.0  DAYS HALF  3 ITS) (24-JUN-2019)      
+  PAV=   260.6  BARSA  WCT=0.152 GOR=   145.49  SM3/SM3 WGR=   0.0012  SM3/SM3   
+
+ STEP  148 TIME=    545.00  DAYS (    +6.0  DAYS REPT  3 ITS) (30-JUN-2019)      
+  PAV=   260.5  BARSA  WCT=0.156 GOR=   145.74  SM3/SM3 WGR=   0.0013  SM3/SM3   
+   425 READING WCONHIST
+   426 READING RPTSCHED
+   427 READING RPTRST  
+
+ @--MESSAGE  AT TIME      545.0   DAYS    (30-JUN-2019):
+ @           ROCKC TRAN_ OUTPUT HAS BEEN RENAMED TO PERM_                    
+ @           FROM 2013.1 FOR COMPATIBILITY WITH E300                         
+   428 READING DATES   
+1                             **********************************************************************  52
+  SIMULATE AT    545.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  49    30 JUN 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  149 TIME=    546.00  DAYS (    +1.0  DAYS REPT  1 ITS) (1-JLY-2019)       
+  PAV=   260.5  BARSA  WCT=0.156 GOR=   145.83  SM3/SM3 WGR=   0.0013  SM3/SM3   
+1                             **********************************************************************  53
+  BALANCE  AT    546.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  50     1 JLY 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+
+                                                     ==================================================
+                                                     :               FIELD TOTALS                     :
+                                                     :         PAV =        260.46  BARSA             :
+                                                     :         PORV=    543870734.   RM3              :
+                                                     :(PRESSURE IS WEIGHTED BY HYDROCARBON PORE VOLUME:
+                                                     : PORE VOLUMES ARE TAKEN AT REFERENCE CONDITIONS):
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :     40238373.       183700.      40422074.:     463219251. :   1395117164.   5543619064.    6938736228.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW THROUGH WELLS    :                                   5219501.:      -4740962. :                                 736602488.:
+ :WELL  MATERIAL BAL. ERROR:                                         7.:           -10. :                                       907.:
+ :FIELD MATERIAL BAL. ERROR:                                       163.:            56. :                                     85708.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :     45456828.       184916.      45641745.:     458478335. :   1201546352.   6473878978.    7675425331.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    1    :
+                                                :     PAV =        277.42  BARSA:
+                                                :     PORV=     92144333.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      1926274.         8730.       1935004.:      86132801. :     43844213.    274863636.     318707849.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        42884.        -6309.         36575.:        470907. :    -47015421.      5937211.     -41078210.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:       -106584. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         2.:           236. :                                      8312.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      1971580.            0.       1971580.:      86497360. :            0.    277637950.     277637950.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :        35819.            0.         35819.:        428558. :           -0.      5044101.       5044101.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:        668599. :            0.            0.             0.:
+ :OUTFLOW TO REGION   4    :        -1593.        -4291.         -5883.:        -78256. :    -32442287.      -301386.     -32743673.:
+ :OUTFLOW TO REGION   8    :        13012.         -449.         12564.:       -605787. :     -2522270.      1878223.       -644047.:
+ :OUTFLOW TO REGION   9    :        -3847.            0.         -3847.:          9603. :            0.      -541731.       -541731.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:        -11190. :            0.            0.             0.:
+ :OUTFLOW TO REGION  11    :           -0.        -1565.         -1565.:           -48. :    -12016314.           -0.     -12016314.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:            -0. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :         1158.            0.          1158.:         59439. :            0.       163089.        163089.:
+ :OUTFLOW TO REGION  18    :        -1667.           -4.         -1671.:           -11. :       -34551.      -305085.       -339636.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    2    :
+                                                :     PAV =        252.59  BARSA:
+                                                :     PORV=     23847184.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      6539590.         5882.       6545472.:      13728819. :     36599118.    891829007.     928428126.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       283596.         -160.        283435.:       -917581. :      -988343.     38695720.      37707377.:
+ :OUTFLOW THROUGH WELLS    :                                    583730.:           -25. :                                  77707027.:
+ :MATERIAL BALANCE ERROR.  :                                        54.:            80. :                                     12624.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      7412691.            0.       7412691.:      12811294. :            0.   1043855155.    1043855155.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :       -35819.           -0.        -35819.:       -428558. :            0.     -5044101.      -5044101.:
+ :OUTFLOW TO REGION   3    :       423551.         -158.        423392.:       -338881. :      -975267.     58846546.      57871279.:
+ :OUTFLOW TO REGION   5    :       -17113.           -0.        -17113.:          -272. :            0.     -2368156.      -2368156.:
+ :OUTFLOW TO REGION   6    :           -0.            0.            -0.:        -57376. :           -0.          -63.           -63.:
+ :OUTFLOW TO REGION   8    :           12.           -0.            12.:         -1920. :            0.         1651.          1651.:
+ :OUTFLOW TO REGION   9    :       -60652.            0.        -60652.:           -76. :            0.     -8540953.      -8540953.:
+ :OUTFLOW TO REGION  12    :          210.           -0.           210.:             6. :            0.        28639.         28639.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:           -25. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :          -93.           -0.           -93.:          -188. :            0.       -13090.        -13090.:
+ :OUTFLOW TO REGION  19    :        35682.           -1.         35682.:          2346. :        -3338.      4498480.       4495142.:
+ :OUTFLOW TO REGION  20    :       -62181.           -2.        -62183.:        -92637. :        -9738.     -8713231.      -8722969.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    3    :
+                                                :     PAV =        266.65  BARSA:
+                                                :     PORV=     16265885.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      1906332.         3084.       1909416.:      12983745. :     19403408.    261780732.     281184140.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :      -379647.        -4094.       -383741.:       -905402. :    -26271369.    -53212469.     -79483838.:
+ :OUTFLOW THROUGH WELLS    :                                    936916.:        258770. :                                 145077195.:
+ :MATERIAL BALANCE ERROR.  :                                        29.:            66. :                                      8656.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      2462620.            0.       2462620.:      12337179. :           -0.    346786153.     346786153.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :            0.            0.             0.:       -668599. :            0.            0.             0.:
+ :OUTFLOW TO REGION   2    :      -423551.          158.       -423392.:        338881. :       975267.    -58846546.     -57871279.:
+ :OUTFLOW TO REGION   4    :            0.            0.             0.:        294204. :            0.            0.             0.:
+ :OUTFLOW TO REGION   5    :            0.            0.             0.:         -1045. :            0.            0.             0.:
+ :OUTFLOW TO REGION   6    :            0.            0.             0.:       -869131. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:         68849. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :           -0.        -4253.         -4253.:       -252380. :    -27246494.           -0.     -27246494.:
+ :OUTFLOW TO REGION  10    :        -2747.            0.         -2747.:          3477. :            0.      -386815.       -386815.:
+ :OUTFLOW TO REGION  11    :         1458.            0.          1458.:        115840. :            0.       207609.        207609.:
+ :OUTFLOW TO REGION  13    :          885.            0.           885.:        -55489. :            0.       124583.        124583.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:             5. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:         -8952. :            0.            0.             0.:
+ :OUTFLOW TO REGION  18    :        56420.           -0.         56420.:           701. :         -142.      7394309.       7394167.:
+ :OUTFLOW TO REGION  20    :       -12112.           -0.        -12112.:        128236. :           -0.     -1705609.      -1705609.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    4    :
+                                                :     PAV =        281.79  BARSA:
+                                                :     PORV=      7720051.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       249472.        82032.        331503.:       4232567. :    655988329.     45492873.     701481203.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :         2650.         7301.          9951.:        -84879. :     54932217.       497276.      55429493.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         3.:           -41. :                                     10459.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       232168.       109289.        341457.:       4147646. :    711432520.     45488634.     756921154.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :         1593.         4291.          5883.:         78256. :     32442287.       301386.      32743673.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:       -294204. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :            0.            0.             0.:          2359. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:            23. :            0.            0.             0.:
+ :OUTFLOW TO REGION  11    :         1057.         3010.          4068.:        128687. :     22489930.       195890.      22685820.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    5    :
+                                                :     PAV =        251.47  BARSA:
+                                                :     PORV=      2279667.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      1027824.          934.       1028758.:        742724. :      5749610.    139553077.     145302687.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       -51237.            0.        -51237.:           293. :            0.     -7224514.      -7224514.:
+ :OUTFLOW THROUGH WELLS    :                                     77049.:           723. :                                  10426728.:
+ :MATERIAL BALANCE ERROR.  :                                         3.:             0. :                                       130.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      1054573.            0.       1054573.:        743740. :            0.    148505030.     148505030.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :        17113.            0.         17113.:           272. :            0.      2368156.       2368156.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:          1045. :            0.            0.             0.:
+ :OUTFLOW TO REGION   6    :            0.            0.             0.:          -121. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :       -15593.            0.        -15593.:             2. :           -0.     -2195829.      -2195829.:
+ :OUTFLOW TO REGION  12    :         1249.            0.          1249.:             9. :           -0.       171483.        171483.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:          -878. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :        -1135.            0.         -1135.:            -3. :           -0.      -159838.       -159838.:
+ :OUTFLOW TO REGION  20    :       -52871.            0.        -52871.:           -33. :            0.     -7408487.      -7408487.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    6    :
+                                                :     PAV =        240.99  BARSA:
+                                                :     PORV=     16715360.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      6549053.        12111.       6561163.:       6708101. :     84488932.    842764744.     927253676.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       -11782.           -0.        -11782.:        892925. :           -1.     -1634333.      -1634334.:
+ :OUTFLOW THROUGH WELLS    :                                    790383.:      -1602484. :                                 107961006.:
+ :MATERIAL BALANCE ERROR.  :                                        27.:             6. :                                      9094.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      7339792.            0.       7339792.:       5998549. :            0.   1033589443.    1033589443.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :            0.           -0.             0.:         57376. :            0.           63.            63.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:        869131. :            0.            0.             0.:
+ :OUTFLOW TO REGION   5    :            0.            0.             0.:           121. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :         1545.            0.          1545.:        -46091. :            0.       217533.        217533.:
+ :OUTFLOW TO REGION  13    :       -13327.           -0.        -13327.:         12409. :           -1.     -1851928.      -1851930.:
+ :OUTFLOW TO REGION  20    :            0.            0.             0.:           -21. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    7    :
+                                                :     PAV =        265.44  BARSA:
+                                                :     PORV=     31732729.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :         1878.           -0.          1878.:      30678468. :           -0.       264537.        264537.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        -1878.           -0.         -1878.:         71493. :            0.      -264529.       -264529.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -0.:            13. :                                        -8.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :            0.            0.             0.:      30749973. :            0.            0.             0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:        -68849. :            0.            0.             0.:
+ :OUTFLOW TO REGION   6    :        -1545.           -0.         -1545.:         46091. :            0.      -217533.       -217533.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:           691. :            0.            0.             0.:
+ :OUTFLOW TO REGION  13    :           -2.            0.            -2.:       -111883. :            0.         -216.          -216.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:          -865. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:         26668. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :         -332.           -0.          -332.:        179639. :            0.       -46779.        -46779.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:            -0. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    8    :
+                                                :     PAV =        279.57  BARSA:
+                                                :     PORV=     99297143.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       459930.         3268.        463199.:      95245101. :     17786934.     66007619.      83794554.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       -19074.        -1474.        -20548.:       1088797. :    -18479460.     -2987226.     -21466686.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:       -781202. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                       -14.:             1. :                                      4366.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       442638.            0.        442638.:      95552697. :            0.     62332233.      62332233.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :       -13012.          449.        -12564.:        605787. :      2522270.     -1878223.        644047.:
+ :OUTFLOW TO REGION   2    :          -12.            0.           -12.:          1920. :            0.        -1651.         -1651.:
+ :OUTFLOW TO REGION   3    :            0.         4253.          4253.:        252380. :     27246494.            0.      27246494.:
+ :OUTFLOW TO REGION   4    :            0.            0.             0.:         -2359. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :         -412.            0.          -412.:        327033. :            0.       -58028.        -58028.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:       -125271. :            0.            0.             0.:
+ :OUTFLOW TO REGION  11    :        -4810.        -6173.        -10984.:       -124227. :    -48234666.      -898583.     -49133250.:
+ :OUTFLOW TO REGION  15    :          -21.            0.           -21.:        -19098. :            0.        -3167.         -3167.:
+ :OUTFLOW TO REGION  16    :            0.            0.             0.:        172777. :            0.            0.             0.:
+ :OUTFLOW TO REGION  18    :         -807.           -2.          -808.:          -143. :       -13557.      -147574.       -161131.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    9    :
+                                                :     PAV =        275.58  BARSA:
+                                                :     PORV=      8461267.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      3150624.           -0.       3150624.:       3780467. :           -0.    443671237.     443671236.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       317718.            0.        317718.:       -396730. :            0.     44740697.      44740697.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -1.:             6. :                                      -117.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      3468341.            0.       3468341.:       3383743. :            0.    488411816.     488411816.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :         3847.           -0.          3847.:         -9603. :            0.       541731.        541731.:
+ :OUTFLOW TO REGION   2    :        60652.           -0.         60652.:            76. :           -0.      8540953.       8540953.:
+ :OUTFLOW TO REGION   5    :        15593.           -0.         15593.:            -2. :            0.      2195829.       2195829.:
+ :OUTFLOW TO REGION   8    :          412.           -0.           412.:       -327033. :           -0.        58028.         58028.:
+ :OUTFLOW TO REGION  10    :      -106803.            0.       -106803.:         90692. :           -0.    -15039988.     -15039988.:
+ :OUTFLOW TO REGION  12    :          651.            0.           651.:             1. :            0.        91736.         91736.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:            12. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:            -3. :           -0.            6.             6.:
+ :OUTFLOW TO REGION  16    :      -258174.           -0.       -258174.:       -157530. :            0.    -36356053.     -36356053.:
+ :OUTFLOW TO REGION  19    :       597445.            0.        597445.:          3238. :            0.     84131864.      84131864.:
+ :OUTFLOW TO REGION  20    :         4095.           -0.          4095.:          3422. :            0.       576590.        576590.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   10    :
+                                                :     PAV =        280.73  BARSA:
+                                                :     PORV=     14236567.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      1009776.           -0.       1009776.:      12358487. :           -0.    142196591.     142196591.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       109070.           -0.        109070.:       -121243. :            0.     15359285.      15359285.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -0.:             0. :                                        -5.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      1118846.            0.       1118846.:      12237245. :            0.    157555872.     157555872.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :            0.            0.             0.:         11190. :            0.            0.             0.:
+ :OUTFLOW TO REGION   3    :         2747.           -0.          2747.:         -3477. :            0.       386815.        386815.:
+ :OUTFLOW TO REGION   4    :            0.            0.             0.:           -23. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:          -691. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :            0.            0.             0.:        125271. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :       106803.           -0.        106803.:        -90692. :            0.     15039988.      15039988.:
+ :OUTFLOW TO REGION  11    :            0.            0.             0.:        -26385. :            0.            0.             0.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:       -118770. :            0.            0.             0.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:         46038. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:        -10700. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :         -504.            0.          -504.:         15602. :            0.       -71008.        -71008.:
+ :OUTFLOW TO REGION  18    :           25.            0.            25.:         -7102. :            0.         3491.          3491.:
+ :OUTFLOW TO REGION  20    :            0.            0.             0.:        -61546. :            0.            0.             0.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:            42. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   11    :
+                                                :     PAV =        281.57  BARSA:
+                                                :     PORV=      7261494.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       393987.        51697.        445684.:       4612700. :    414718947.     71440464.     486159411.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :         1006.         3417.          4423.:         -9206. :     27224809.       256443.      27481252.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         0.:            -7. :                                     13577.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       382426.        67682.        450108.:       4603487. :    438725604.     74928635.     513654240.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :            0.         1565.          1565.:            48. :     12016314.            0.      12016314.:
+ :OUTFLOW TO REGION   3    :        -1458.           -0.         -1458.:       -115840. :            0.      -207609.       -207609.:
+ :OUTFLOW TO REGION   4    :        -1057.        -3010.         -4068.:       -128687. :    -22489930.      -195890.     -22685820.:
+ :OUTFLOW TO REGION   8    :         4810.         6173.         10984.:        124227. :     48234666.       898583.      49133250.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:         26385. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:            37. :            0.            0.             0.:
+ :OUTFLOW TO REGION  18    :        -1288.        -1311.         -2599.:         84623. :    -10536240.      -238642.     -10774883.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   12    :
+                                                :     PAV =        203.57  BARSA:
+                                                :     PORV=      1639655.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       824197.         2514.        826711.:        357892. :     22026906.     88632660.     110659566.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        -3227.           -0.         -3227.:            34. :          -66.      -446760.       -446827.:
+ :OUTFLOW THROUGH WELLS    :                                     63322.:          -400. :                                  14661152.:
+ :MATERIAL BALANCE ERROR.  :                                       -11.:             3. :                                      4491.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       886794.            0.        886794.:        357528. :           -0.    124878382.     124878382.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :         -210.            0.          -210.:            -6. :            0.       -28639.        -28639.:
+ :OUTFLOW TO REGION   5    :        -1249.           -0.         -1249.:            -9. :            0.      -171483.       -171483.:
+ :OUTFLOW TO REGION   9    :         -651.           -0.          -651.:            -1. :            0.       -91736.        -91736.:
+ :OUTFLOW TO REGION  16    :         -347.           -0.          -347.:            -1. :           -0.       -48895.        -48895.:
+ :OUTFLOW TO REGION  19    :         -770.           -0.          -770.:            50. :          -66.      -106008.       -106074.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   13    :
+                                                :     PAV =        250.99  BARSA:
+                                                :     PORV=     12433656.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      4337493.         4822.       4342316.:       5847354. :     30544834.    582534403.     613079237.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :         5130.            0.          5130.:        271332. :            1.       697864.        697865.:
+ :OUTFLOW THROUGH WELLS    :                                    696258.:      -1077340. :                                  96483473.:
+ :MATERIAL BALANCE ERROR.  :                                        52.:            15. :                                      1048.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      5043755.            0.       5043755.:       5041361. :            0.    710261623.     710261623.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :            0.            0.             0.:            25. :            0.            0.             0.:
+ :OUTFLOW TO REGION   3    :         -885.           -0.          -885.:         55489. :            0.      -124583.       -124583.:
+ :OUTFLOW TO REGION   5    :            0.            0.             0.:           878. :            0.            0.             0.:
+ :OUTFLOW TO REGION   6    :        13327.            0.         13327.:        -12409. :            1.      1851928.       1851930.:
+ :OUTFLOW TO REGION   7    :            2.           -0.             2.:        111883. :            0.          216.           216.:
+ :OUTFLOW TO REGION   9    :            0.            0.             0.:           -12. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:        118770. :            0.            0.             0.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:            -3. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :        -7314.           -0.         -7314.:         -3288. :           -0.     -1029698.      -1029698.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   14    :
+                                                :     PAV =        272.43  BARSA:
+                                                :     PORV=     25328539.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :           40.            0.            40.:      24506105. :            0.         5591.          5591.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :          -40.            0.           -40.:         49476. :           -0.        -5580.         -5580.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -0.:            -8. :                                       -11.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :            0.            0.             0.:      24555573. :            0.            0.             0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:            -5. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:           865. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:        -46038. :            0.            0.             0.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:             3. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:         13001. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :          -40.            0.           -40.:         76835. :           -0.        -5580.         -5580.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:          4816. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   15    :
+                                                :     PAV =        282.66  BARSA:
+                                                :     PORV=     89597072.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :        48499.           45.         48544.:      86528291. :       220526.      7346219.       7566745.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       -11647.          -27.        -11674.:       1102536. :      -210674.     -2164061.      -2374735.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:       -888213. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -1.:          -209. :                                       -85.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :        36869.            0.         36869.:      86742405. :            0.      5191924.       5191924.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :            0.            0.             0.:             0. :            0.            0.             0.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:          8952. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :           21.           -0.            21.:         19098. :           -0.         3167.          3167.:
+ :OUTFLOW TO REGION   9    :           -0.           -0.            -0.:             3. :            0.           -6.            -6.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:         10700. :            0.            0.             0.:
+ :OUTFLOW TO REGION  11    :            0.            0.             0.:           -37. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :         -212.           -0.          -212.:       1059405. :            0.       -29818.        -29818.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:         30443. :            0.            0.             0.:
+ :OUTFLOW TO REGION  18    :       -11456.          -27.        -11483.:        -26029. :      -210674.     -2137403.      -2348078.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   16    :
+                                                :     PAV =        273.09  BARSA:
+                                                :     PORV=     36879049.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      3961084.           -0.       3961084.:      30084867. :           -0.    557799869.     557799869.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       310613.            0.        310613.:       -290390. :            0.     43740549.      43740549.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -9.:           -41. :                                     -1242.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      4271689.            0.       4271689.:      29794436. :            0.    601539175.     601539175.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :        -1158.           -0.         -1158.:        -59439. :            0.      -163089.       -163089.:
+ :OUTFLOW TO REGION   2    :           93.            0.            93.:           188. :           -0.        13090.         13090.:
+ :OUTFLOW TO REGION   5    :         1135.           -0.          1135.:             3. :            0.       159838.        159838.:
+ :OUTFLOW TO REGION   8    :            0.            0.             0.:       -172777. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :       258174.            0.        258174.:        157530. :            0.     36356053.      36356053.:
+ :OUTFLOW TO REGION  12    :          347.            0.           347.:             1. :            0.        48895.         48895.:
+ :OUTFLOW TO REGION  15    :          212.            0.           212.:      -1059405. :           -0.        29818.         29818.:
+ :OUTFLOW TO REGION  17    :       -18676.           -0.        -18676.:         -4606. :            0.     -2629984.      -2629984.:
+ :OUTFLOW TO REGION  19    :        62625.           -0.         62625.:        313622. :           -0.      8818877.       8818877.:
+ :OUTFLOW TO REGION  20    :         7861.            0.          7861.:        534495. :            0.      1107050.       1107050.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   17    :
+                                                :     PAV =        282.14  BARSA:
+                                                :     PORV=      5687619.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       339544.           -0.        339544.:       5025980. :           -0.     47814536.      47814536.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        19180.            0.         19180.:        -14308. :           -0.      2700992.       2700992.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         0.:            -4. :                                         4.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       358724.            0.        358724.:       5011669. :            0.     50515533.      50515533.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:        -26668. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :          504.           -0.           504.:        -15602. :            0.        71008.         71008.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:        -13001. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:        -30443. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :        18676.            0.         18676.:          4606. :           -0.      2629984.       2629984.:
+ :OUTFLOW TO REGION  18    :            0.            0.             0.:        -90519. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :            0.            0.             0.:         -2835. :            0.            0.             0.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:        160156. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   18    :
+                                                :     PAV =        282.52  BARSA:
+                                                :     PORV=      3145457.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       745279.         6195.        751474.:       1685333. :     49243285.    133779748.     183023033.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       -41227.         1344.        -39882.:         38480. :     10795164.     -4569095.       6226069.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         4.:            -2. :                                      5411.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       703651.         7945.        711595.:       1723811. :     51388228.    137866285.     189254513.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :         1667.            4.          1671.:            11. :        34551.       305085.        339636.:
+ :OUTFLOW TO REGION   3    :       -56420.            0.        -56420.:          -701. :          142.     -7394309.      -7394167.:
+ :OUTFLOW TO REGION   8    :          807.            2.           808.:           143. :        13557.       147574.        161131.:
+ :OUTFLOW TO REGION  10    :          -25.           -0.           -25.:          7102. :            0.        -3491.         -3491.:
+ :OUTFLOW TO REGION  11    :         1288.         1311.          2599.:        -84623. :     10536240.       238642.      10774883.:
+ :OUTFLOW TO REGION  15    :        11456.           27.         11483.:         26029. :       210674.      2137403.       2348078.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:         90519. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   19    :
+                                                :     PAV =        253.94  BARSA:
+                                                :     PORV=      2355763.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       971489.         1646.        973135.:        872281. :     10119047.    132697430.     142816477.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :      -694983.            1.       -694983.:       -319256. :         3404.    -97343214.     -97339810.:
+ :OUTFLOW THROUGH WELLS    :                                    923500.:         61760. :                                 123735584.:
+ :MATERIAL BALANCE ERROR.  :                                       -10.:             1. :                                      2925.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      1201642.            0.       1201642.:        614786. :            0.    169215175.     169215175.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :       -35682.            1.        -35682.:         -2346. :         3338.     -4498480.      -4495142.:
+ :OUTFLOW TO REGION   9    :      -597445.           -0.       -597445.:         -3238. :            0.    -84131864.     -84131864.:
+ :OUTFLOW TO REGION  12    :          770.            0.           770.:           -50. :           66.       106008.        106074.:
+ :OUTFLOW TO REGION  16    :       -62625.            0.        -62625.:       -313622. :            0.     -8818877.      -8818877.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   20    :
+                                                :     PAV =        260.61  BARSA:
+                                                :     PORV=     18527269.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      5796010.          740.       5796749.:       9755319. :      4383074.    813144092.     817527166.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       122894.            2.        122896.:      -1013265. :         9738.     17225745.      17235483.:
+ :OUTFLOW THROUGH WELLS    :                                   1148350.:       -605976. :                                 160551229.:
+ :MATERIAL BALANCE ERROR.  :                                        35.:            72. :                                      6079.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      7068030.            0.       7068030.:       8136150. :           -0.    995319957.     995319957.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :        62181.            2.         62183.:         92637. :         9738.      8713231.       8722969.:
+ :OUTFLOW TO REGION   3    :        12112.            0.         12112.:       -128236. :            0.      1705609.       1705609.:
+ :OUTFLOW TO REGION   5    :        52871.           -0.         52871.:            33. :            0.      7408487.       7408487.:
+ :OUTFLOW TO REGION   6    :            0.            0.             0.:            21. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :          332.            0.           332.:       -179639. :            0.        46779.         46779.:
+ :OUTFLOW TO REGION   9    :        -4095.            0.         -4095.:         -3422. :            0.      -576590.       -576590.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:         61546. :            0.            0.             0.:
+ :OUTFLOW TO REGION  13    :         7314.            0.          7314.:          3288. :            0.      1029698.       1029698.:
+ :OUTFLOW TO REGION  14    :           40.           -0.            40.:        -76835. :            0.         5580.          5580.:
+ :OUTFLOW TO REGION  16    :        -7861.           -0.         -7861.:       -534495. :            0.     -1107050.      -1107050.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:          2835. :            0.            0.             0.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:       -250998. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   21    :
+                                                :     PAV =        280.41  BARSA:
+                                                :     PORV=     28314973.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :            0.            0.             0.:      27351847. :            0.            0.             0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :            0.            0.             0.:         85984. :            0.            0.             0.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         0.:          -130. :                                         0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :            0.            0.             0.:      27437701. :            0.            0.             0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:             0. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:           -42. :            0.            0.             0.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:         -4816. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:       -160156. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :            0.            0.             0.:        250998. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                     ===================================
+                                                     :  FIPNUM OIL RECOVERY FACTORS    :
+ :---------:-----------------------------:---------------------------------------------:--------------------------------------------:
+ :         :                             : RATIO OF       RATIO OF       RATIO OF      : RATIO OF       RATIO OF       RATIO OF     :
+ : REGION  : MOBILE OIIP    MOBILE OIIP  : DISPLACED OIL  DISPLACED OIL  DISPLACED OIL : WELL FLOW      WELL FLOW      WELL FLOW    :
+ :         : (W.R.T WATER)  (W.R.T GAS)  : TO INITIAL     TO INITIAL     TO INITIAL    : TO INITIAL     TO INITIAL     TO INITIAL   :
+ :         :                             : OIP            MOBILE OIL     MOBILE OIL    : OIP            MOBILE OIL     MOBILE OIL   :
+ :         :                             :                (WATER)        (GAS)         :                (WATER)        (GAS)        :
+ :---------:-----------------------------:---------------------------------------------:--------------------------------------------:
+ :   FIELD :    3.467E+07      3.799E+07 :   0.11436        0.15055       0.13741      :   0.11436        0.15055        0.13741    :
+ :       1 :    1.464E+06      1.608E+06 :   0.01855        0.02498       0.02274      :         0              0              0    :
+ :       2 :    5.735E+06      6.204E+06 :   0.11699        0.15120       0.13978      :   0.07875        0.10178        0.09408    :
+ :       3 :    1.865E+06      2.037E+06 :   0.22464        0.29660       0.27162      :   0.38045        0.50232        0.46002    :
+ :       4 :    1.659E+05      2.936E+05 :   0.02915        0.06000       0.03390      :         0              0              0    :
+ :       5 :    7.773E+05      8.642E+05 :   0.02448        0.03321       0.02987      :   0.07306        0.09913        0.08915    :
+ :       6 :    5.619E+06      6.139E+06 :   0.10608        0.13857       0.12683      :   0.10768        0.14066        0.12874    :
+ :       7 :    0.000E+00      0.000E+00 :                                             :                                            :
+ :       8 :    2.984E+05      3.384E+05 :  -0.04645       -0.06891      -0.06076      :         0              0              0    :
+ :       9 :    2.613E+06      2.859E+06 :   0.09160        0.12157       0.11112      :         0              0              0    :
+ :      10 :    8.101E+05      9.000E+05 :   0.09748        0.13464       0.12118      :         0              0              0    :
+ :      11 :    2.426E+05      3.463E+05 :   0.00983        0.01824       0.01277      :         0              0              0    :
+ :      12 :    6.806E+05      7.415E+05 :   0.06775        0.08828       0.08103      :   0.07141        0.09303        0.08540    :
+ :      13 :    3.885E+06      4.220E+06 :   0.13907        0.18056       0.16620      :   0.13804        0.17922        0.16497    :
+ :      14 :    0.000E+00      0.000E+00 :                                             :                                            :
+ :      15 :    2.836E+04      3.076E+04 :  -0.31666       -0.41163      -0.37951      :         0              0              0    :
+ :      16 :    3.251E+06      3.546E+06 :   0.07271        0.09556       0.08760      :         0              0              0    :
+ :      17 :    2.645E+05      2.934E+05 :   0.05347        0.07252       0.06537      :         0              0              0    :
+ :      18 :    5.443E+05      5.977E+05 :  -0.05604       -0.07326      -0.06672      :         0              0              0    :
+ :      19 :    9.198E+05      1.002E+06 :   0.19016        0.24842       0.22796      :   0.76853        1.00397        0.92128    :
+ :      20 :    5.505E+06      5.963E+06 :   0.17986        0.23094       0.21321      :   0.16247        0.20861        0.19259    :
+ :      21 :    0.000E+00      0.000E+00 :                                             :                                            :
+ ====================================================================================================================================
+
+ @--MESSAGE  AT TIME      546.0   DAYS    ( 1-JLY-2019):
+ @           GRAPHICS ONLY RESTART FILE WRITTEN   REPORT    50               
+ @           RESTART INCLUDES INTERBLOCK FLOWS                               
+ @                            PHASE RESERVOIR DENSITIES                      
+   429 READING WCONHIST
+   430 READING RPTSCHED
+   431 READING RPTRST  
+
+ @--COMMENT  AT TIME      546.0   DAYS    ( 1-JLY-2019):
+ @           RESTART OUTPUT HAS BEEN TURNED OFF WITH BASIC=0                 
+ @           ALL OTHER MNEMONICS WILL BE IGNORED                             
+   432 READING DATES   
+1                             **********************************************************************  54
+  SIMULATE AT    546.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  50     1 JLY 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  150 TIME=    547.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (2-JLY-2019)       
+  PAV=   260.4  BARSA  WCT=0.157 GOR=   145.96  SM3/SM3 WGR=   0.0013  SM3/SM3   
+
+ STEP  151 TIME=    550.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-JLY-2019)       
+  PAV=   260.4  BARSA  WCT=0.159 GOR=   146.12  SM3/SM3 WGR=   0.0013  SM3/SM3   
+
+ STEP  152 TIME=    559.00  DAYS (    +9.0  DAYS MAXF  4 ITS) (14-JLY-2019)      
+  PAV=   260.2  BARSA  WCT=0.166 GOR=   146.51  SM3/SM3 WGR=   0.0014  SM3/SM3   
+
+ STEP  153 TIME=    572.00  DAYS (   +13.0  DAYS REPT  4 ITS) (27-JLY-2019)      
+  PAV=   260.0  BARSA  WCT=0.176 GOR=   146.98  SM3/SM3 WGR=   0.0014  SM3/SM3   
+   433 READING WCONHIST
+   434 READING DATES   
+1                             **********************************************************************  55
+  SIMULATE AT    572.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  51    27 JLY 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  154 TIME=    573.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (28-JLY-2019)      
+  PAV=   260.0  BARSA  WCT=0.176 GOR=   147.09  SM3/SM3 WGR=   0.0015  SM3/SM3   
+
+ STEP  155 TIME=    575.00  DAYS (    +2.0  DAYS HALF  3 ITS) (30-JLY-2019)      
+  PAV=   260.0  BARSA  WCT=0.178 GOR=   147.22  SM3/SM3 WGR=   0.0015  SM3/SM3   
+
+ STEP  156 TIME=    577.00  DAYS (    +2.0  DAYS REPT  2 ITS) (1-AUG-2019)       
+  PAV=   259.9  BARSA  WCT=0.179 GOR=   147.32  SM3/SM3 WGR=   0.0015  SM3/SM3   
+   435 READING WCONHIST
+   436 READING DATES   
+1                             **********************************************************************  56
+  SIMULATE AT    577.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  52     1 AUG 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  157 TIME=    578.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (2-AUG-2019)       
+  PAV=   259.9  BARSA  WCT=0.180 GOR=   147.40  SM3/SM3 WGR=   0.0015  SM3/SM3   
+
+ STEP  158 TIME=    581.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-AUG-2019)       
+  PAV=   259.8  BARSA  WCT=0.182 GOR=   147.55  SM3/SM3 WGR=   0.0015  SM3/SM3   
+
+ STEP  159 TIME=    586.50  DAYS (    +5.5  DAYS HALF  4 ITS) (10-AUG-2019)      
+  PAV=   259.8  BARSA  WCT=0.186 GOR=   147.79  SM3/SM3 WGR=   0.0015  SM3/SM3   
+
+ STEP  160 TIME=    592.00  DAYS (    +5.5  DAYS REPT  4 ITS) (16-AUG-2019)      
+  PAV=   259.7  BARSA  WCT=0.190 GOR=   148.05  SM3/SM3 WGR=   0.0016  SM3/SM3   
+   437 READING WCONHIST
+   438 READING DATES   
+1                             **********************************************************************  57
+  SIMULATE AT    592.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  53    16 AUG 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  161 TIME=    593.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (17-AUG-2019)      
+  PAV=   259.6  BARSA  WCT=0.190 GOR=   148.24  SM3/SM3 WGR=   0.0016  SM3/SM3   
+
+ STEP  162 TIME=    596.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (20-AUG-2019)      
+  PAV=   259.6  BARSA  WCT=0.192 GOR=   148.47  SM3/SM3 WGR=   0.0016  SM3/SM3   
+
+ STEP  163 TIME=    600.00  DAYS (    +4.0  DAYS REPT  3 ITS) (24-AUG-2019)      
+  PAV=   259.5  BARSA  WCT=0.195 GOR=   148.76  SM3/SM3 WGR=   0.0016  SM3/SM3   
+   439 READING WCONHIST
+   440 READING DATES   
+1                             **********************************************************************  58
+  SIMULATE AT    600.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  54    24 AUG 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  164 TIME=    601.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (25-AUG-2019)      
+  PAV=   259.5  BARSA  WCT=0.195 GOR=   149.03  SM3/SM3 WGR=   0.0016  SM3/SM3   
+
+ STEP  165 TIME=    604.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (28-AUG-2019)      
+  PAV=   259.4  BARSA  WCT=0.197 GOR=   149.22  SM3/SM3 WGR=   0.0016  SM3/SM3   
+
+ STEP  166 TIME=    608.00  DAYS (    +4.0  DAYS REPT  5 ITS) (1-SEP-2019)       
+  PAV=   259.4  BARSA  WCT=0.200 GOR=   149.41  SM3/SM3 WGR=   0.0017  SM3/SM3   
+   441 READING WCONHIST
+   442 READING DATES   
+1                             **********************************************************************  59
+  SIMULATE AT    608.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  55     1 SEP 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  167 TIME=    609.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (2-SEP-2019)       
+  PAV=   259.3  BARSA  WCT=0.200 GOR=   149.68  SM3/SM3 WGR=   0.0017  SM3/SM3   
+
+ STEP  168 TIME=    611.00  DAYS (    +2.0  DAYS HALF  2 ITS) (4-SEP-2019)       
+  PAV=   259.3  BARSA  WCT=0.201 GOR=   149.79  SM3/SM3 WGR=   0.0017  SM3/SM3   
+
+ STEP  169 TIME=    613.00  DAYS (    +2.0  DAYS REPT  1 ITS) (6-SEP-2019)       
+  PAV=   259.3  BARSA  WCT=0.202 GOR=   149.88  SM3/SM3 WGR=   0.0017  SM3/SM3   
+   443 READING WCONHIST
+   444 READING DATES   
+1                             **********************************************************************  60
+  SIMULATE AT    613.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  56     6 SEP 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  170 TIME=    614.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (7-SEP-2019)       
+  PAV=   259.3  BARSA  WCT=0.202 GOR=   150.07  SM3/SM3 WGR=   0.0017  SM3/SM3   
+
+ STEP  171 TIME=    617.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (10-SEP-2019)      
+  PAV=   259.2  BARSA  WCT=0.204 GOR=   150.23  SM3/SM3 WGR=   0.0017  SM3/SM3   
+
+ STEP  172 TIME=    626.00  DAYS (    +9.0  DAYS MAXF  4 ITS) (19-SEP-2019)      
+  PAV=   259.0  BARSA  WCT=0.209 GOR=   150.73  SM3/SM3 WGR=   0.0018  SM3/SM3   
+
+ STEP  173 TIME=    638.00  DAYS (   +12.0  DAYS REPT  4 ITS) (1-OCT-2019)       
+  PAV=   258.8  BARSA  WCT=0.215 GOR=   151.56  SM3/SM3 WGR=   0.0018  SM3/SM3   
+   445 READING WCONHIST
+   446 READING DATES   
+1                             **********************************************************************  61
+  SIMULATE AT    638.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  57     1 OCT 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  174 TIME=    639.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (2-OCT-2019)       
+  PAV=   258.8  BARSA  WCT=0.216 GOR=   151.10  SM3/SM3 WGR=   0.0018  SM3/SM3   
+
+ STEP  175 TIME=    642.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-OCT-2019)       
+  PAV=   258.7  BARSA  WCT=0.218 GOR=   151.32  SM3/SM3 WGR=   0.0018  SM3/SM3   
+
+ STEP  176 TIME=    649.00  DAYS (    +7.0  DAYS HALF  4 ITS) (12-OCT-2019)      
+  PAV=   258.6  BARSA  WCT=0.222 GOR=   151.90  SM3/SM3 WGR=   0.0019  SM3/SM3   
+
+ STEP  177 TIME=    656.00  DAYS (    +7.0  DAYS REPT  4 ITS) (19-OCT-2019)      
+  PAV=   258.5  BARSA  WCT=0.225 GOR=   152.51  SM3/SM3 WGR=   0.0019  SM3/SM3   
+   447 READING WCONHIST
+   448 READING DATES   
+1                             **********************************************************************  62
+  SIMULATE AT    656.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  58    19 OCT 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  178 TIME=    657.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (20-OCT-2019)      
+  PAV=   258.4  BARSA  WCT=0.226 GOR=   152.04  SM3/SM3 WGR=   0.0019  SM3/SM3   
+
+ STEP  179 TIME=    660.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (23-OCT-2019)      
+  PAV=   258.4  BARSA  WCT=0.228 GOR=   152.29  SM3/SM3 WGR=   0.0019  SM3/SM3   
+
+ STEP  180 TIME=    669.00  DAYS (    +9.0  DAYS REPT  3 ITS) (1-NOV-2019)       
+  PAV=   258.2  BARSA  WCT=0.233 GOR=   153.10  SM3/SM3 WGR=   0.0020  SM3/SM3   
+   449 READING WCONHIST
+   450 READING WCONINJH
+   451 READING DATES   
+1                             **********************************************************************  63
+  SIMULATE AT    669.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  59     1 NOV 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  181 TIME=    670.00  DAYS (    +1.0  DAYS REPT  4 ITS) (2-NOV-2019)       
+  PAV=   258.3  BARSA  WCT= 0.00 GOR= 0.00000   SM3/SM3 WGR= 0.00000   SM3/SM3   
+   452 READING WCONHIST
+   453 READING WCONINJH
+   454 READING DATES   
+1                             **********************************************************************  64
+  SIMULATE AT    670.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  60     2 NOV 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  182 TIME=    671.00  DAYS (    +1.0  DAYS MAXW  3 ITS) (3-NOV-2019)       
+  PAV=   258.3  BARSA  WCT=0.231 GOR=   147.69  SM3/SM3 WGR=   0.0020  SM3/SM3   
+
+ STEP  183 TIME=    672.08  DAYS (    +1.1  DAYS TRNC  4 ITS) (4-NOV-2019)       
+  PAV=   258.3  BARSA  WCT=0.233 GOR=   149.05  SM3/SM3 WGR=   0.0020  SM3/SM3   
+
+ STEP  184 TIME=    674.04  DAYS (    +2.0  DAYS HALF  2 ITS) (6-NOV-2019)       
+  PAV=   258.2  BARSA  WCT=0.236 GOR=   150.73  SM3/SM3 WGR=   0.0020  SM3/SM3   
+
+ STEP  185 TIME=    676.00  DAYS (    +2.0  DAYS REPT  3 ITS) (8-NOV-2019)       
+  PAV=   258.2  BARSA  WCT=0.237 GOR=   151.89  SM3/SM3 WGR=   0.0020  SM3/SM3   
+   455 READING WCONHIST
+   456 READING DATES   
+1                             **********************************************************************  65
+  SIMULATE AT    676.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  61     8 NOV 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  186 TIME=    677.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (9-NOV-2019)       
+  PAV=   258.2  BARSA  WCT=0.237 GOR=   152.07  SM3/SM3 WGR=   0.0020  SM3/SM3   
+
+ STEP  187 TIME=    680.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (12-NOV-2019)      
+  PAV=   258.2  BARSA  WCT=0.239 GOR=   152.90  SM3/SM3 WGR=   0.0021  SM3/SM3   
+
+ STEP  188 TIME=    684.00  DAYS (    +4.0  DAYS REPT  2 ITS) (16-NOV-2019)      
+  PAV=   258.1  BARSA  WCT=0.241 GOR=   153.56  SM3/SM3 WGR=   0.0021  SM3/SM3   
+   457 READING WCONHIST
+   458 READING DATES   
+1                             **********************************************************************  66
+  SIMULATE AT    684.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  62    16 NOV 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  189 TIME=    685.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (17-NOV-2019)      
+  PAV=   258.1  BARSA  WCT=0.242 GOR=   153.38  SM3/SM3 WGR=   0.0021  SM3/SM3   
+
+ STEP  190 TIME=    688.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (20-NOV-2019)      
+  PAV=   258.1  BARSA  WCT=0.243 GOR=   153.79  SM3/SM3 WGR=   0.0021  SM3/SM3   
+
+ STEP  191 TIME=    697.00  DAYS (    +9.0  DAYS REPT  3 ITS) (29-NOV-2019)      
+  PAV=   257.9  BARSA  WCT=0.249 GOR=   154.93  SM3/SM3 WGR=   0.0021  SM3/SM3   
+   459 READING WCONHIST
+   460 READING DATES   
+1                             **********************************************************************  67
+  SIMULATE AT    697.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  63    29 NOV 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  192 TIME=    698.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (30-NOV-2019)      
+  PAV=   257.9  BARSA  WCT=0.250 GOR=   154.82  SM3/SM3 WGR=   0.0021  SM3/SM3   
+
+ STEP  193 TIME=    699.00  DAYS (    +1.0  DAYS REPT  2 ITS) (1-DEC-2019)       
+  PAV=   257.9  BARSA  WCT=0.250 GOR=   154.95  SM3/SM3 WGR=   0.0022  SM3/SM3   
+   461 READING WCONHIST
+   462 READING DATES   
+1                             **********************************************************************  68
+  SIMULATE AT    699.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  64     1 DEC 2019   *  RUN                                                                   * RUN AT 09:09 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  194 TIME=    700.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (2-DEC-2019)       
+  PAV=   257.9  BARSA  WCT=0.252 GOR=   154.42  SM3/SM3 WGR=   0.0022  SM3/SM3   
+
+ STEP  195 TIME=    703.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-DEC-2019)       
+  PAV=   257.9  BARSA  WCT=0.254 GOR=   154.84  SM3/SM3 WGR=   0.0022  SM3/SM3   
+
+ STEP  196 TIME=    712.00  DAYS (    +9.0  DAYS MAXF  6 ITS) (14-DEC-2019)      
+  PAV=   257.8  BARSA  WCT=0.260 GOR=   156.18  SM3/SM3 WGR=   0.0022  SM3/SM3   
+
+ STEP  197 TIME=    730.00  DAYS (   +18.0  DAYS REPT  5 ITS) (1-JAN-2020)       
+  PAV=   257.7  BARSA  WCT=0.273 GOR=   158.80  SM3/SM3 WGR=   0.0024  SM3/SM3   
+   463 READING WCONHIST
+   464 READING DATES   
+1                             **********************************************************************  69
+  SIMULATE AT    730.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  65     1 JAN 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  198 TIME=    731.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (2-JAN-2020)       
+  PAV=   257.6  BARSA  WCT=0.275 GOR=   157.97  SM3/SM3 WGR=   0.0024  SM3/SM3   
+
+ STEP  199 TIME=    734.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-JAN-2020)       
+  PAV=   257.6  BARSA  WCT=0.277 GOR=   158.38  SM3/SM3 WGR=   0.0024  SM3/SM3   
+
+ STEP  200 TIME=    740.00  DAYS (    +6.0  DAYS REPT  4 ITS) (11-JAN-2020)      
+  PAV=   257.6  BARSA  WCT=0.282 GOR=   159.20  SM3/SM3 WGR=   0.0025  SM3/SM3   
+   465 READING WCONHIST
+   466 READING DATES   
+1                             **********************************************************************  70
+  SIMULATE AT    740.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  66    11 JAN 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  201 TIME=    741.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (12-JAN-2020)      
+  PAV=   257.6  BARSA  WCT=0.284 GOR=   158.66  SM3/SM3 WGR=   0.0025  SM3/SM3   
+
+ STEP  202 TIME=    744.00  DAYS (    +3.0  DAYS MAXF  3 ITS) (15-JAN-2020)      
+  PAV=   257.6  BARSA  WCT=0.286 GOR=   159.01  SM3/SM3 WGR=   0.0025  SM3/SM3   
+
+ STEP  203 TIME=    752.00  DAYS (    +8.0  DAYS HALF  3 ITS) (23-JAN-2020)      
+  PAV=   257.6  BARSA  WCT=0.292 GOR=   159.88  SM3/SM3 WGR=   0.0026  SM3/SM3   
+
+ STEP  204 TIME=    760.00  DAYS (    +8.0  DAYS REPT  4 ITS) (31-JAN-2020)      
+  PAV=   257.5  BARSA  WCT=0.298 GOR=   160.65  SM3/SM3 WGR=   0.0026  SM3/SM3   
+   467 READING WCONHIST
+   468 READING DATES   
+1                             **********************************************************************  71
+  SIMULATE AT    760.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  67    31 JAN 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  205 TIME=    761.00  DAYS (    +1.0  DAYS REPT  1 ITS) (1-FEB-2020)       
+  PAV=   257.5  BARSA  WCT=0.300 GOR=   160.30  SM3/SM3 WGR=   0.0027  SM3/SM3   
+   469 READING WCONHIST
+   470 READING DATES   
+1                             **********************************************************************  72
+  SIMULATE AT    761.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  68     1 FEB 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  206 TIME=    762.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (2-FEB-2020)       
+  PAV=   257.5  BARSA  WCT=0.301 GOR=   160.13  SM3/SM3 WGR=   0.0027  SM3/SM3   
+
+ STEP  207 TIME=    765.00  DAYS (    +3.0  DAYS MAXF  4 ITS) (5-FEB-2020)       
+  PAV=   257.5  BARSA  WCT=0.303 GOR=   160.39  SM3/SM3 WGR=   0.0027  SM3/SM3   
+
+ STEP  208 TIME=    768.00  DAYS (    +3.0  DAYS REPT  2 ITS) (8-FEB-2020)       
+  PAV=   257.5  BARSA  WCT=0.305 GOR=   160.64  SM3/SM3 WGR=   0.0027  SM3/SM3   
+   471 READING WCONHIST
+   472 READING DATES   
+1                             **********************************************************************  73
+  SIMULATE AT    768.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  69     8 FEB 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  209 TIME=    769.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (9-FEB-2020)       
+  PAV=   257.5  BARSA  WCT=0.307 GOR=   160.24  SM3/SM3 WGR=   0.0028  SM3/SM3   
+
+ STEP  210 TIME=    772.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (12-FEB-2020)      
+  PAV=   257.5  BARSA  WCT=0.309 GOR=   160.44  SM3/SM3 WGR=   0.0028  SM3/SM3   
+
+ STEP  211 TIME=    781.00  DAYS (    +9.0  DAYS REPT  3 ITS) (21-FEB-2020)      
+  PAV=   257.5  BARSA  WCT=0.315 GOR=   160.99  SM3/SM3 WGR=   0.0029  SM3/SM3   
+   473 READING WCONHIST
+   474 READING DATES   
+1                             **********************************************************************  74
+  SIMULATE AT    781.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  70    21 FEB 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  212 TIME=    782.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (22-FEB-2020)      
+  PAV=   257.5  BARSA  WCT=0.317 GOR=   160.51  SM3/SM3 WGR=   0.0029  SM3/SM3   
+
+ STEP  213 TIME=    785.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (25-FEB-2020)      
+  PAV=   257.5  BARSA  WCT=0.318 GOR=   160.63  SM3/SM3 WGR=   0.0029  SM3/SM3   
+
+ STEP  214 TIME=    790.00  DAYS (    +5.0  DAYS REPT  3 ITS) (1-MAR-2020)       
+  PAV=   257.5  BARSA  WCT=0.322 GOR=   160.86  SM3/SM3 WGR=   0.0029  SM3/SM3   
+   475 READING WCONHIST
+   476 READING DATES   
+1                             **********************************************************************  75
+  SIMULATE AT    790.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  71     1 MAR 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  215 TIME=    791.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (2-MAR-2020)       
+  PAV=   257.5  BARSA  WCT=0.324 GOR=   159.88  SM3/SM3 WGR=   0.0030  SM3/SM3   
+
+ STEP  216 TIME=    794.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-MAR-2020)       
+  PAV=   257.5  BARSA  WCT=0.326 GOR=   159.91  SM3/SM3 WGR=   0.0030  SM3/SM3   
+
+ STEP  217 TIME=    803.00  DAYS (    +9.0  DAYS MAXF  3 ITS) (14-MAR-2020)      
+  PAV=   257.5  BARSA  WCT=0.332 GOR=   160.07  SM3/SM3 WGR=   0.0031  SM3/SM3   
+
+ STEP  218 TIME=    812.00  DAYS (    +9.0  DAYS HALF  4 ITS) (23-MAR-2020)      
+  PAV=   257.5  BARSA  WCT=0.337 GOR=   160.13  SM3/SM3 WGR=   0.0032  SM3/SM3   
+
+ STEP  219 TIME=    821.00  DAYS (    +9.0  DAYS REPT  5 ITS) (1-APR-2020)       
+  PAV=   257.6  BARSA  WCT=0.343 GOR=   160.12  SM3/SM3 WGR=   0.0033  SM3/SM3   
+   477 READING WCONHIST
+   478 READING DATES   
+1                             **********************************************************************  76
+  SIMULATE AT    821.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  72     1 APR 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  220 TIME=    822.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (2-APR-2020)       
+  PAV=   257.6  BARSA  WCT=0.345 GOR=   159.34  SM3/SM3 WGR=   0.0033  SM3/SM3   
+
+ STEP  221 TIME=    824.00  DAYS (    +2.0  DAYS REPT  2 ITS) (4-APR-2020)       
+  PAV=   257.6  BARSA  WCT=0.346 GOR=   159.26  SM3/SM3 WGR=   0.0033  SM3/SM3   
+   479 READING WCONHIST
+   480 READING DATES   
+1                             **********************************************************************  77
+  SIMULATE AT    824.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  73     4 APR 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  222 TIME=    825.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (5-APR-2020)       
+  PAV=   257.6  BARSA  WCT=0.348 GOR=   158.83  SM3/SM3 WGR=   0.0034  SM3/SM3   
+
+ STEP  223 TIME=    828.00  DAYS (    +3.0  DAYS MAXF  4 ITS) (8-APR-2020)       
+  PAV=   257.6  BARSA  WCT=0.349 GOR=   158.73  SM3/SM3 WGR=   0.0034  SM3/SM3   
+
+ STEP  224 TIME=    836.00  DAYS (    +8.0  DAYS HALF  3 ITS) (16-APR-2020)      
+  PAV=   257.6  BARSA  WCT=0.354 GOR=   158.54  SM3/SM3 WGR=   0.0035  SM3/SM3   
+
+ STEP  225 TIME=    844.00  DAYS (    +8.0  DAYS REPT  3 ITS) (24-APR-2020)      
+  PAV=   257.7  BARSA  WCT=0.359 GOR=   158.33  SM3/SM3 WGR=   0.0035  SM3/SM3   
+   481 READING WCONHIST
+   482 READING DATES   
+1                             **********************************************************************  78
+  SIMULATE AT    844.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  74    24 APR 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  226 TIME=    845.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (25-APR-2020)      
+  PAV=   257.7  BARSA  WCT=0.361 GOR=   157.89  SM3/SM3 WGR=   0.0036  SM3/SM3   
+
+ STEP  227 TIME=    848.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (28-APR-2020)      
+  PAV=   257.7  BARSA  WCT=0.363 GOR=   157.74  SM3/SM3 WGR=   0.0036  SM3/SM3   
+
+ STEP  228 TIME=    851.00  DAYS (    +3.0  DAYS REPT  2 ITS) (1-MAY-2020)       
+  PAV=   257.7  BARSA  WCT=0.364 GOR=   157.63  SM3/SM3 WGR=   0.0036  SM3/SM3   
+   483 READING WCONHIST
+   484 READING WCONINJH
+   485 READING DATES   
+1                             **********************************************************************  79
+  SIMULATE AT    851.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  75     1 MAY 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  229 TIME=    852.00  DAYS (    +1.0  DAYS REPT  5 ITS) (2-MAY-2020)       
+  PAV=   257.8  BARSA  WCT= 0.00 GOR= 0.00000   SM3/SM3 WGR= 0.00000   SM3/SM3   
+   486 READING DATES   
+1                             **********************************************************************  80
+  SIMULATE AT    852.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  76     2 MAY 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  230 TIME=    853.01  DAYS (    +1.0  DAYS TRNC  3 ITS) (3-MAY-2020)       
+  PAV=   257.9  BARSA  WCT= 0.00 GOR= 0.00000   SM3/SM3 WGR= 0.00000   SM3/SM3   
+
+ STEP  231 TIME=    854.00  DAYS (   +23.9 HOURS HALF  2 ITS) (4-MAY-2020)       
+  PAV=   257.9  BARSA  WCT= 0.00 GOR= 0.00000   SM3/SM3 WGR= 0.00000   SM3/SM3   
+
+ STEP  232 TIME=    855.00  DAYS (   +23.9 HOURS REPT  2 ITS) (5-MAY-2020)       
+  PAV=   258.0  BARSA  WCT= 0.00 GOR= 0.00000   SM3/SM3 WGR= 0.00000   SM3/SM3   
+   487 READING WCONHIST
+   488 READING WCONINJH
+   489 READING DATES   
+1                             **********************************************************************  81
+  SIMULATE AT    855.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  77     5 MAY 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  233 TIME=    856.00  DAYS (    +1.0  DAYS MAXW  3 ITS) (6-MAY-2020)       
+  PAV=   257.9  BARSA  WCT=0.356 GOR=   150.39  SM3/SM3 WGR=   0.0037  SM3/SM3   
+
+ STEP  234 TIME=    857.73  DAYS (    +1.7  DAYS TRNC  3 ITS) (7-MAY-2020)       
+  PAV=   257.9  BARSA  WCT=0.361 GOR=   151.06  SM3/SM3 WGR=   0.0037  SM3/SM3   
+
+ STEP  235 TIME=    860.68  DAYS (    +2.9  DAYS TRNC  3 ITS) (10-MAY-2020)      
+  PAV=   257.9  BARSA  WCT=0.365 GOR=   151.77  SM3/SM3 WGR=   0.0038  SM3/SM3   
+
+ STEP  236 TIME=    865.00  DAYS (    +4.3  DAYS REPT  4 ITS) (15-MAY-2020)      
+  PAV=   258.0  BARSA  WCT=0.369 GOR=   152.77  SM3/SM3 WGR=   0.0038  SM3/SM3   
+   490 READING WCONHIST
+   491 READING DATES   
+1                             **********************************************************************  82
+  SIMULATE AT    865.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  78    15 MAY 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  237 TIME=    866.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (16-MAY-2020)      
+  PAV=   258.0  BARSA  WCT=0.368 GOR=   152.82  SM3/SM3 WGR=   0.0038  SM3/SM3   
+
+ STEP  238 TIME=    869.00  DAYS (    +3.0  DAYS MAXF  3 ITS) (19-MAY-2020)      
+  PAV=   258.0  BARSA  WCT=0.370 GOR=   153.46  SM3/SM3 WGR=   0.0038  SM3/SM3   
+
+ STEP  239 TIME=    875.50  DAYS (    +6.5  DAYS HALF  5 ITS) (25-MAY-2020)      
+  PAV=   258.0  BARSA  WCT=0.375 GOR=   153.81  SM3/SM3 WGR=   0.0039  SM3/SM3   
+
+ STEP  240 TIME=    882.00  DAYS (    +6.5  DAYS REPT  6 ITS) (1-JUN-2020)       
+  PAV=   258.0  BARSA  WCT=0.379 GOR=   153.85  SM3/SM3 WGR=   0.0040  SM3/SM3   
+   492 READING WCONHIST
+   493 READING DATES   
+1                             **********************************************************************  83
+  SIMULATE AT    882.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  79     1 JUN 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  241 TIME=    883.00  DAYS (    +1.0  DAYS MAXW  1 ITS) (2-JUN-2020)       
+  PAV=   258.0  BARSA  WCT=0.382 GOR=   153.76  SM3/SM3 WGR=   0.0040  SM3/SM3   
+
+ STEP  242 TIME=    886.00  DAYS (    +3.0  DAYS MAXF  2 ITS) (5-JUN-2020)       
+  PAV=   258.1  BARSA  WCT=0.384 GOR=   153.62  SM3/SM3 WGR=   0.0041  SM3/SM3   
+
+ STEP  243 TIME=    895.00  DAYS (    +9.0  DAYS MAXF  4 ITS) (14-JUN-2020)      
+  PAV=   258.1  BARSA  WCT=0.390 GOR=   153.32  SM3/SM3 WGR=   0.0042  SM3/SM3   
+
+ STEP  244 TIME=    908.00  DAYS (   +13.0  DAYS REPT  6 ITS) (27-JUN-2020)      
+  PAV=   258.2  BARSA  WCT=0.397 GOR=   152.66  SM3/SM3 WGR=   0.0043  SM3/SM3   
+   494 READING WCONHIST
+   495 READING DATES   
+1                             **********************************************************************  84
+  SIMULATE AT    908.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  80    27 JUN 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  245 TIME=    909.00  DAYS (    +1.0  DAYS MAXW  2 ITS) (28-JUN-2020)      
+  PAV=   258.2  BARSA  WCT=0.399 GOR=   152.82  SM3/SM3 WGR=   0.0043  SM3/SM3   
+
+ STEP  246 TIME=    911.00  DAYS (    +2.0  DAYS REPT  2 ITS) (30-JUN-2020)      
+  PAV=   258.2  BARSA  WCT=0.400 GOR=   152.60  SM3/SM3 WGR=   0.0044  SM3/SM3   
+   496 READING WCONHIST
+   497 READING RPTSCHED
+   498 READING RPTRST  
+
+ @--MESSAGE  AT TIME      911.0   DAYS    (30-JUN-2020):
+ @           ROCKC TRAN_ OUTPUT HAS BEEN RENAMED TO PERM_                    
+ @           FROM 2013.1 FOR COMPATIBILITY WITH E300                         
+   499 READING DATES   
+1                             **********************************************************************  85
+  SIMULATE AT    911.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  81    30 JUN 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+ STEP  247 TIME=    912.00  DAYS (    +1.0  DAYS REPT  1 ITS) (1-JLY-2020)       
+  PAV=   258.2  BARSA  WCT=0.401 GOR=   152.54  SM3/SM3 WGR=   0.0044  SM3/SM3   
+1                             **********************************************************************  86
+  BALANCE  AT    912.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  82     1 JLY 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+
+
+                                                     ==================================================
+                                                     :               FIELD TOTALS                     :
+                                                     :         PAV =        258.18  BARSA             :
+                                                     :         PORV=    543870734.   RM3              :
+                                                     :(PRESSURE IS WEIGHTED BY HYDROCARBON PORE VOLUME:
+                                                     : PORE VOLUMES ARE TAKEN AT REFERENCE CONDITIONS):
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :     37021408.       185875.      37207283.:     467761466. :   1413209543.   5030115622.    6443325165.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW THROUGH WELLS    :                                   8434215.:      -9285147. :                                1231985861.:
+ :WELL  MATERIAL BAL. ERROR:                                        -1.:             1. :                                      -127.:
+ :FIELD MATERIAL BAL. ERROR:                                       248.:          2015. :                                    114432.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :     45456828.       184916.      45641745.:     458478335. :   1201546352.   6473878978.    7675425331.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    1    :
+                                                :     PAV =        279.20  BARSA:
+                                                :     PORV=     92144333.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      1914166.        12469.       1926635.:      86090794. :     61966517.    273722865.     335689382.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        53586.        -8649.         44937.:        686681. :    -65420907.      7359421.     -58061487.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:       -280807. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         9.:           692. :                                     10055.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      1971580.            0.       1971580.:      86497360. :            0.    277637950.     277637950.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :        46218.           -0.         46218.:       1006945. :           -0.      6508471.       6508471.:
+ :OUTFLOW TO REGION   3    :            0.           18.            18.:       1133824. :       110651.           -0.        110651.:
+ :OUTFLOW TO REGION   4    :        -2783.        -5598.         -8382.:       -147938. :    -42978513.      -519870.     -43498383.:
+ :OUTFLOW TO REGION   8    :        18416.         -611.         17805.:      -1352357. :     -3375160.      2682698.       -692462.:
+ :OUTFLOW TO REGION   9    :        -6549.            0.         -6549.:        -15722. :            0.      -922219.       -922219.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:        -23401. :            0.            0.             0.:
+ :OUTFLOW TO REGION  11    :           -0.        -2431.         -2431.:          -219. :    -18974449.           -1.     -18974450.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:            -1. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :         1858.            0.          1858.:         85575. :            0.       261672.        261672.:
+ :OUTFLOW TO REGION  18    :        -3575.          -26.         -3601.:           -24. :      -203437.      -651331.       -854768.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    2    :
+                                                :     PAV =        254.95  BARSA:
+                                                :     PORV=     23847184.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      5785989.         5410.       5791399.:      14782113. :     33261038.    796405634.     829666671.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       356621.         -259.        356362.:      -1967559. :     -1648581.     48370836.      46722255.:
+ :OUTFLOW THROUGH WELLS    :                                   1264850.:         -3370. :                                 167449620.:
+ :MATERIAL BALANCE ERROR.  :                                        80.:           110. :                                     16608.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      7412691.            0.       7412691.:      12811294. :            0.   1043855155.    1043855155.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :       -46218.            0.        -46218.:      -1006945. :            0.     -6508471.      -6508471.:
+ :OUTFLOW TO REGION   3    :       574208.         -255.        573953.:       -488741. :     -1624356.     79523380.      77899024.:
+ :OUTFLOW TO REGION   5    :       -44851.           -0.        -44851.:          -602. :            0.     -6227033.      -6227033.:
+ :OUTFLOW TO REGION   6    :          -27.           -0.           -27.:       -128681. :           -0.        -3854.         -3854.:
+ :OUTFLOW TO REGION   8    :           12.           -0.            12.:         -4920. :            0.         1651.          1651.:
+ :OUTFLOW TO REGION   9    :      -135730.           -0.       -135730.:          -182. :            0.    -19113469.     -19113469.:
+ :OUTFLOW TO REGION  12    :          515.           -0.           515.:            13. :            0.        70312.         70312.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:           -91. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :         -321.           -0.          -321.:          -486. :            0.       -45219.        -45219.:
+ :OUTFLOW TO REGION  19    :        92026.           -1.         92024.:          3905. :        -6770.     12294386.      12287616.:
+ :OUTFLOW TO REGION  20    :       -82992.           -3.        -82995.:       -340828. :       -17455.    -11620847.     -11638302.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    3    :
+                                                :     PAV =        268.18  BARSA:
+                                                :     PORV=     16265885.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      1739174.         3239.       1742413.:      13211440. :     20091130.    240219593.     260310723.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :      -514643.        -8363.       -523006.:      -1622658. :    -53981682.    -72360441.    -126342124.:
+ :OUTFLOW THROUGH WELLS    :                                   1243182.:        748366. :                                 212804809.:
+ :MATERIAL BALANCE ERROR.  :                                        30.:            31. :                                     12745.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      2462620.            0.       2462620.:      12337179. :           -0.    346786153.     346786153.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :            0.          -18.           -18.:      -1133824. :      -110651.            0.       -110651.:
+ :OUTFLOW TO REGION   2    :      -574208.          255.       -573953.:        488741. :      1624356.    -79523380.     -77899024.:
+ :OUTFLOW TO REGION   4    :            0.            0.             0.:        557542. :            0.            0.             0.:
+ :OUTFLOW TO REGION   5    :            0.            0.             0.:         -2042. :            0.            0.             0.:
+ :OUTFLOW TO REGION   6    :            0.            0.             0.:      -1619468. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:        136291. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :            0.        -8601.         -8601.:       -436237. :    -55495210.           -0.     -55495210.:
+ :OUTFLOW TO REGION  10    :        -4702.            0.         -4702.:          5920. :            0.      -662115.       -662115.:
+ :OUTFLOW TO REGION  11    :         2618.            0.          2618.:        221747. :            0.       372003.        372003.:
+ :OUTFLOW TO REGION  13    :         1005.            0.          1005.:       -126134. :            0.       141572.        141572.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:            10. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:        -17252. :            0.            0.             0.:
+ :OUTFLOW TO REGION  18    :        81698.           -0.         81698.:         70145. :         -177.     10276357.      10276180.:
+ :OUTFLOW TO REGION  20    :       -21054.           -0.        -21054.:        231903. :           -0.     -2964879.      -2964879.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    4    :
+                                                :     PAV =        282.62  BARSA:
+                                                :     PORV=      7720051.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       247008.        80436.        327444.:       4324607. :    636904782.     45234301.     682139083.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :         4329.         9682.         14012.:       -176924. :     73980180.       804245.      74784426.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         1.:           -37. :                                     -2354.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       232168.       109289.        341457.:       4147646. :    711432520.     45488634.     756921154.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :         2783.         5598.          8382.:        147938. :     42978513.       519870.      43498383.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:       -557542. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :            0.            0.             0.:          4320. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:            37. :            0.            0.             0.:
+ :OUTFLOW TO REGION  11    :         1546.         4084.          5630.:        228323. :     31001668.       284375.      31286042.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    5    :
+                                                :     PAV =        252.91  BARSA:
+                                                :     PORV=      2279667.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      1028847.          864.       1029711.:        741841. :      5261384.    140630739.     145892123.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :      -119603.            0.       -119603.:           589. :            0.    -16871402.     -16871402.:
+ :OUTFLOW THROUGH WELLS    :                                    144463.:          1310. :                                  19484142.:
+ :MATERIAL BALANCE ERROR.  :                                         3.:             0. :                                       168.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      1054573.            0.       1054573.:        743740. :            0.    148505030.     148505030.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :        44851.            0.         44851.:           602. :            0.      6227033.       6227033.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:          2042. :            0.            0.             0.:
+ :OUTFLOW TO REGION   6    :            0.            0.             0.:          -228. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :       -42535.            0.        -42535.:            -7. :           -0.     -5989709.      -5989709.:
+ :OUTFLOW TO REGION  12    :         3084.            0.          3084.:            21. :           -0.       422035.        422035.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:         -1774. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :        -3130.           -0.         -3130.:            -8. :           -0.      -440725.       -440725.:
+ :OUTFLOW TO REGION  20    :      -121873.           -0.       -121873.:           -60. :            0.    -17090036.     -17090036.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    6    :
+                                                :     PAV =        213.68  BARSA:
+                                                :     PORV=     16715360.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      5925549.        15654.       5941204.:       7379832. :    138210670.    671209767.     809420436.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       -30326.           -5.        -30332.:       1647105. :       -36795.     -4045342.      -4082137.:
+ :OUTFLOW THROUGH WELLS    :                                   1428842.:      -3028422. :                                 228213726.:
+ :MATERIAL BALANCE ERROR.  :                                        78.:            34. :                                     37417.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      7339792.            0.       7339792.:       5998549. :            0.   1033589443.    1033589443.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :           27.            0.            27.:        128681. :            0.         3854.          3854.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:       1619468. :            0.            0.             0.:
+ :OUTFLOW TO REGION   5    :            0.            0.             0.:           228. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :         1544.            0.          1544.:       -121834. :            0.       217393.        217393.:
+ :OUTFLOW TO REGION  13    :       -31897.           -5.        -31903.:         20657. :       -36795.     -4266589.      -4303383.:
+ :OUTFLOW TO REGION  20    :            0.            0.             0.:           -95. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    7    :
+                                                :     PAV =        267.89  BARSA:
+                                                :     PORV=     31732729.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :         1896.           -0.          1896.:      30682452. :           -0.       266952.        266952.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        -1896.           -0.         -1896.:         67522. :            0.      -266943.       -266943.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -0.:            -1. :                                        -8.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :            0.            0.             0.:      30749973. :            0.            0.             0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:       -136291. :            0.            0.             0.:
+ :OUTFLOW TO REGION   6    :        -1544.           -0.         -1544.:        121834. :            0.      -217393.       -217393.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:          1074. :            0.            0.             0.:
+ :OUTFLOW TO REGION  13    :           -2.            0.            -2.:       -216604. :            0.         -225.          -225.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:         -1170. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:         49962. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :         -350.           -0.          -350.:        248718. :            0.       -49325.        -49325.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:            -0. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    8    :
+                                                :     PAV =        281.21  BARSA:
+                                                :     PORV=     99297143.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       466197.         3697.        469894.:      95250382. :     19747018.     67147920.      86894937.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       -26402.         -842.        -27243.:       2354021. :    -20435731.     -4131682.     -24567413.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:      -2051846. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                       -13.:           141. :                                      4709.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       442638.            0.        442638.:      95552697. :            0.     62332233.      62332233.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :       -18416.          611.        -17805.:       1352357. :      3375160.     -2682698.        692462.:
+ :OUTFLOW TO REGION   2    :          -12.            0.           -12.:          4920. :            0.        -1651.         -1651.:
+ :OUTFLOW TO REGION   3    :            0.         8601.          8601.:        436237. :     55495210.            0.      55495210.:
+ :OUTFLOW TO REGION   4    :            0.            0.             0.:         -4320. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :         -566.            0.          -566.:        768535. :            0.       -79676.        -79676.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:       -283058. :            0.            0.             0.:
+ :OUTFLOW TO REGION  11    :        -5705.       -10043.        -15748.:       -206753. :    -79222392.     -1060081.     -80282473.:
+ :OUTFLOW TO REGION  15    :         -101.            0.          -101.:        -91391. :            0.       -15719.        -15719.:
+ :OUTFLOW TO REGION  16    :            0.            0.             0.:        377996. :            0.            0.             0.:
+ :OUTFLOW TO REGION  18    :        -1602.          -11.         -1613.:          -504. :       -83709.      -291858.       -375567.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION    9    :
+                                                :     PAV =        278.47  BARSA:
+                                                :     PORV=      8461267.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      2821844.           -0.       2821844.:       4243856. :           -0.    397372237.     397372237.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       646496.            0.        646496.:       -860119. :            0.     91039440.      91039440.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         1.:             6. :                                       140.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      3468341.            0.       3468341.:       3383743. :            0.    488411816.     488411816.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :         6549.           -0.          6549.:         15722. :           -0.       922219.        922219.:
+ :OUTFLOW TO REGION   2    :       135730.            0.        135730.:           182. :            0.     19113469.      19113469.:
+ :OUTFLOW TO REGION   5    :        42535.           -0.         42535.:             7. :            0.      5989709.       5989709.:
+ :OUTFLOW TO REGION   8    :          566.           -0.           566.:       -768535. :           -0.        79676.         79676.:
+ :OUTFLOW TO REGION  10    :      -164406.           -0.       -164406.:        243870. :           -0.    -23151664.     -23151664.:
+ :OUTFLOW TO REGION  12    :         1582.           -0.          1582.:             1. :            0.       222766.        222766.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:            16. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:            -1. :            0.           16.            16.:
+ :OUTFLOW TO REGION  16    :      -432744.           -0.       -432744.:       -378535. :            0.    -60938964.     -60938964.:
+ :OUTFLOW TO REGION  19    :      1047230.            0.       1047230.:         19669. :            0.    147470774.     147470774.:
+ :OUTFLOW TO REGION  20    :         9455.           -0.          9455.:          7485. :            0.      1331440.       1331440.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   10    :
+                                                :     PAV =        282.98  BARSA:
+                                                :     PORV=     14236567.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       950639.           -0.        950639.:      12443808. :           -0.    133868935.     133868935.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       168206.            0.        168206.:       -206559. :            0.     23686809.      23686809.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         1.:            -4. :                                       127.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      1118846.            0.       1118846.:      12237245. :            0.    157555872.     157555872.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :            0.            0.             0.:         23401. :            0.            0.             0.:
+ :OUTFLOW TO REGION   3    :         4702.           -0.          4702.:         -5920. :            0.       662115.        662115.:
+ :OUTFLOW TO REGION   4    :            0.            0.             0.:           -37. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:         -1074. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :            0.            0.             0.:        283058. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :       164406.            0.        164406.:       -243870. :            0.     23151664.      23151664.:
+ :OUTFLOW TO REGION  11    :            0.            0.             0.:        -39709. :            0.            0.             0.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:       -223708. :            0.            0.             0.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:        107634. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:        -18749. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :         -972.            0.          -972.:         35886. :            0.      -136814.       -136814.:
+ :OUTFLOW TO REGION  18    :           70.            0.            70.:         -6372. :            0.         9844.          9844.:
+ :OUTFLOW TO REGION  20    :            0.            0.             0.:       -117184. :            0.            0.             0.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:            84. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   11    :
+                                                :     PAV =        282.60  BARSA:
+                                                :     PORV=      7261494.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       396209.        50640.        446849.:       4671602. :    401308420.     72154745.     473463165.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        -1768.         5027.          3259.:        -68107. :     40382947.      -203575.      40179372.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         0.:            -8. :                                     11702.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       382426.        67682.        450108.:       4603487. :    438725604.     74928635.     513654240.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :            0.         2431.          2431.:           219. :     18974449.            1.      18974450.:
+ :OUTFLOW TO REGION   3    :        -2618.           -0.         -2618.:       -221747. :            0.      -372003.       -372003.:
+ :OUTFLOW TO REGION   4    :        -1546.        -4084.         -5630.:       -228323. :    -31001668.      -284375.     -31286042.:
+ :OUTFLOW TO REGION   8    :         5705.        10043.         15748.:        206753. :     79222392.      1060081.      80282473.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:         39709. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:            62. :            0.            0.             0.:
+ :OUTFLOW TO REGION  18    :        -3308.        -3364.         -6672.:        135220. :    -26812226.      -607278.     -27419505.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   12    :
+                                                :     PAV =        201.03  BARSA:
+                                                :     PORV=      1639655.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       828184.         2357.        830541.:        358962. :     21108291.     87858187.     108966478.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        -7970.           -0.         -7970.:             2. :         -553.     -1103334.      -1103886.:
+ :OUTFLOW THROUGH WELLS    :                                     64237.:         -1439. :                                  17011663.:
+ :MATERIAL BALANCE ERROR.  :                                       -13.:             3. :                                      4127.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       886794.            0.        886794.:        357528. :           -0.    124878382.     124878382.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :         -515.            0.          -515.:           -13. :            0.       -70312.        -70312.:
+ :OUTFLOW TO REGION   5    :        -3084.           -0.         -3084.:           -21. :            0.      -422035.       -422035.:
+ :OUTFLOW TO REGION   9    :        -1582.            0.         -1582.:            -1. :            0.      -222766.       -222766.:
+ :OUTFLOW TO REGION  16    :         -833.            0.          -833.:            -1. :            0.      -117336.       -117336.:
+ :OUTFLOW TO REGION  19    :        -1956.           -0.         -1956.:            39. :         -553.      -270885.       -271438.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   13    :
+                                                :     PAV =        252.14  BARSA:
+                                                :     PORV=     12433656.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      3905289.         4880.       3910169.:       6443954. :     30661937.    526013970.     556675906.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        17337.            5.         17342.:        539517. :        36794.      2217134.       2253928.:
+ :OUTFLOW THROUGH WELLS    :                                   1116191.:      -1942132. :                                 151328213.:
+ :MATERIAL BALANCE ERROR.  :                                        52.:            21. :                                      3576.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      5043755.            0.       5043755.:       5041361. :            0.    710261623.     710261623.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :            0.            0.             0.:            91. :            0.            0.             0.:
+ :OUTFLOW TO REGION   3    :        -1005.           -0.         -1005.:        126134. :            0.      -141572.       -141572.:
+ :OUTFLOW TO REGION   5    :            0.            0.             0.:          1774. :            0.            0.             0.:
+ :OUTFLOW TO REGION   6    :        31897.            5.         31903.:        -20657. :        36795.      4266589.       4303383.:
+ :OUTFLOW TO REGION   7    :            2.           -0.             2.:        216604. :            0.          225.           225.:
+ :OUTFLOW TO REGION   9    :            0.            0.             0.:           -16. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:        223708. :            0.            0.             0.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:            -3. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :       -13557.           -0.        -13557.:         -8119. :           -0.     -1908108.      -1908108.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   14    :
+                                                :     PAV =        275.05  BARSA:
+                                                :     PORV=     25328539.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :           40.            0.            40.:      24509372. :            0.         5591.          5591.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :          -40.            0.           -40.:         46205. :           -0.        -5580.         -5580.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -0.:            -3. :                                       -11.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :            0.            0.             0.:      24555573. :            0.            0.             0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:           -10. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:          1170. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:       -107634. :            0.            0.             0.:
+ :OUTFLOW TO REGION  13    :            0.            0.             0.:             3. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:         23276. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :          -40.            0.           -40.:        119825. :           -0.        -5580.         -5580.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:          9575. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   15    :
+                                                :     PAV =        284.90  BARSA:
+                                                :     PORV=     89597072.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :        48376.           39.         48415.:      86556574. :       186090.      7350245.       7536335.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       -11520.          -25.        -11546.:       2516398. :      -201986.     -2142384.      -2344370.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:      -2331347. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                        -0.:           780. :                                       -41.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :        36869.            0.         36869.:      86742405. :            0.      5191924.       5191924.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :            0.            0.             0.:             1. :            0.            0.             0.:
+ :OUTFLOW TO REGION   3    :            0.            0.             0.:         17252. :            0.            0.             0.:
+ :OUTFLOW TO REGION   8    :          101.           -0.           101.:         91391. :           -0.        15719.         15719.:
+ :OUTFLOW TO REGION   9    :           -0.           -0.            -0.:             1. :            0.          -16.           -16.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:         18749. :            0.            0.             0.:
+ :OUTFLOW TO REGION  11    :            0.            0.             0.:           -62. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :         -354.           -0.          -354.:       2354924. :            0.       -49864.        -49864.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:         46161. :            0.            0.             0.:
+ :OUTFLOW TO REGION  18    :       -11267.          -25.        -11292.:        -12019. :      -201986.     -2108222.      -2310208.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   16    :
+                                                :     PAV =        276.37  BARSA:
+                                                :     PORV=     36879049.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      3764152.           -0.       3764152.:      30375214. :           -0.    530067950.     530067949.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       507534.            0.        507534.:       -580908. :            0.     71470894.      71470894.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         2.:           129. :                                       331.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      4271689.            0.       4271689.:      29794436. :            0.    601539175.     601539175.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :        -1858.           -0.         -1858.:        -85575. :            0.      -261672.       -261672.:
+ :OUTFLOW TO REGION   2    :          321.            0.           321.:           486. :           -0.        45219.         45219.:
+ :OUTFLOW TO REGION   5    :         3130.            0.          3130.:             8. :            0.       440725.        440725.:
+ :OUTFLOW TO REGION   8    :            0.            0.             0.:       -377996. :            0.            0.             0.:
+ :OUTFLOW TO REGION   9    :       432744.            0.        432744.:        378535. :            0.     60938964.      60938964.:
+ :OUTFLOW TO REGION  12    :          833.           -0.           833.:             1. :           -0.       117336.        117336.:
+ :OUTFLOW TO REGION  15    :          354.            0.           354.:      -2354924. :            0.        49864.         49864.:
+ :OUTFLOW TO REGION  17    :       -23822.           -0.        -23822.:         22824. :            0.     -3354546.      -3354546.:
+ :OUTFLOW TO REGION  19    :        77598.           -0.         77598.:        585194. :           -0.     10927281.      10927281.:
+ :OUTFLOW TO REGION  20    :        18234.           -0.         18234.:       1250540. :            0.      2567724.       2567724.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   17    :
+                                                :     PAV =        284.91  BARSA:
+                                                :     PORV=      5687619.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       333931.           -0.        333931.:       5035158. :           -0.     47024129.      47024129.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :        24793.            0.         24793.:        -23490. :            0.      3491359.       3491359.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         0.:             1. :                                        45.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       358724.            0.        358724.:       5011669. :            0.     50515533.      50515533.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:        -49962. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :          972.           -0.           972.:        -35886. :            0.       136814.        136814.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:        -23276. :            0.            0.             0.:
+ :OUTFLOW TO REGION  15    :            0.            0.             0.:        -46161. :            0.            0.             0.:
+ :OUTFLOW TO REGION  16    :        23822.            0.         23822.:        -22824. :            0.      3354546.       3354546.:
+ :OUTFLOW TO REGION  18    :            0.            0.             0.:       -177336. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :            0.            0.             0.:         -6604. :            0.            0.             0.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:        338558. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   18    :
+                                                :     PAV =        283.82  BARSA:
+                                                :     PORV=      3145457.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       766179.         3999.        770178.:       1732919. :     31334296.    137241110.     168575406.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       -62016.         3426.        -58591.:         -9109. :     27301536.     -6627512.      20674023.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         8.:             2. :                                      5084.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       703651.         7945.        711595.:       1723811. :     51388228.    137866285.     189254513.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   1    :         3575.           26.          3601.:            24. :       203437.       651331.        854768.:
+ :OUTFLOW TO REGION   3    :       -81698.            0.        -81698.:        -70145. :          177.    -10276357.     -10276180.:
+ :OUTFLOW TO REGION   8    :         1602.           11.          1613.:           504. :        83709.       291858.        375567.:
+ :OUTFLOW TO REGION  10    :          -70.           -0.           -70.:          6372. :            0.        -9844.         -9844.:
+ :OUTFLOW TO REGION  11    :         3308.         3364.          6672.:       -135220. :     26812226.       607278.      27419505.:
+ :OUTFLOW TO REGION  15    :        11267.           25.         11292.:         12019. :       201986.      2108222.       2310208.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:        177336. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   19    :
+                                                :     PAV =        257.03  BARSA:
+                                                :     PORV=      2355763.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       890767.         1864.        892631.:        977023. :     11256599.    122981241.     134237840.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :     -1214897.            1.      -1214895.:       -608807. :         7322.   -170421556.    -170414233.:
+ :OUTFLOW THROUGH WELLS    :                                   1523938.:        246551. :                                 205388109.:
+ :MATERIAL BALANCE ERROR.  :                                       -32.:            18. :                                      3460.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      1201642.            0.       1201642.:        614786. :            0.    169215175.     169215175.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :       -92026.            1.        -92024.:         -3905. :         6770.    -12294386.     -12287616.:
+ :OUTFLOW TO REGION   9    :     -1047230.           -0.      -1047230.:        -19669. :            0.   -147470774.    -147470774.:
+ :OUTFLOW TO REGION  12    :         1956.            0.          1956.:           -39. :          553.       270885.        271438.:
+ :OUTFLOW TO REGION  16    :       -77598.            0.        -77598.:       -585194. :            0.    -10927281.     -10927281.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   20    :
+                                                :     PAV =        262.96  BARSA:
+                                                :     PORV=     18527269.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      5206970.          327.       5207297.:      10589800. :      1911372.    733339514.     735250887.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :       212178.            3.        212181.:      -1811725. :        17455.     29739612.      29757067.:
+ :OUTFLOW THROUGH WELLS    :                                   1648511.:       -642010. :                                 230305452.:
+ :MATERIAL BALANCE ERROR.  :                                        40.:            85. :                                      6552.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :      7068030.            0.       7068030.:       8136150. :           -0.    995319957.     995319957.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   2    :        82992.            3.         82995.:        340828. :        17455.     11620847.      11638302.:
+ :OUTFLOW TO REGION   3    :        21054.            0.         21054.:       -231903. :            0.      2964879.       2964879.:
+ :OUTFLOW TO REGION   5    :       121873.            0.        121873.:            60. :            0.     17090036.      17090036.:
+ :OUTFLOW TO REGION   6    :            0.            0.             0.:            95. :            0.            0.             0.:
+ :OUTFLOW TO REGION   7    :          350.            0.           350.:       -248718. :            0.        49325.         49325.:
+ :OUTFLOW TO REGION   9    :        -9455.            0.         -9455.:         -7485. :            0.     -1331440.      -1331440.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:        117184. :            0.            0.             0.:
+ :OUTFLOW TO REGION  13    :        13557.            0.         13557.:          8119. :            0.      1908108.       1908108.:
+ :OUTFLOW TO REGION  14    :           40.           -0.            40.:       -119825. :            0.         5580.          5580.:
+ :OUTFLOW TO REGION  16    :       -18234.            0.        -18234.:      -1250540. :            0.     -2567724.      -2567724.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:          6604. :            0.            0.             0.:
+ :OUTFLOW TO REGION  21    :            0.            0.             0.:       -426143. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                =================================
+                                                : FIPNUM  REPORT REGION   21    :
+                                                :     PAV =        283.37  BARSA:
+                                                :     PORV=     28314973.   RM3 :
+                           :--------------- OIL    SM3  ---------------:-- WAT    SM3  -:--------------- GAS    SM3  ---------------:
+                           :     LIQUID         VAPOUR         TOTAL   :       TOTAL    :       FREE      DISSOLVED         TOTAL   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :            0.            0.             0.:      27359762. :            0.            0.             0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO OTHER REGIONS :            0.            0.             0.:         77925. :            0.            0.             0.:
+ :OUTFLOW THROUGH WELLS    :                                         0.:             0. :                                         0.:
+ :MATERIAL BALANCE ERROR.  :                                         0.:            14. :                                         0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :            0.            0.             0.:      27437701. :            0.            0.             0.:
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :OUTFLOW TO REGION   7    :            0.            0.             0.:             0. :            0.            0.             0.:
+ :OUTFLOW TO REGION  10    :            0.            0.             0.:           -84. :            0.            0.             0.:
+ :OUTFLOW TO REGION  14    :            0.            0.             0.:         -9575. :            0.            0.             0.:
+ :OUTFLOW TO REGION  17    :            0.            0.             0.:       -338558. :            0.            0.             0.:
+ :OUTFLOW TO REGION  20    :            0.            0.             0.:        426143. :            0.            0.             0.:
+ ====================================================================================================================================
+
+
+                                                     ===================================
+                                                     :  FIPNUM OIL RECOVERY FACTORS    :
+ :---------:-----------------------------:---------------------------------------------:--------------------------------------------:
+ :         :                             : RATIO OF       RATIO OF       RATIO OF      : RATIO OF       RATIO OF       RATIO OF     :
+ : REGION  : MOBILE OIIP    MOBILE OIIP  : DISPLACED OIL  DISPLACED OIL  DISPLACED OIL : WELL FLOW      WELL FLOW      WELL FLOW    :
+ :         : (W.R.T WATER)  (W.R.T GAS)  : TO INITIAL     TO INITIAL     TO INITIAL    : TO INITIAL     TO INITIAL     TO INITIAL   :
+ :         :                             : OIP            MOBILE OIL     MOBILE OIL    : OIP            MOBILE OIL     MOBILE OIL   :
+ :         :                             :                (WATER)        (GAS)         :                (WATER)        (GAS)        :
+ :---------:-----------------------------:---------------------------------------------:--------------------------------------------:
+ :   FIELD :    3.467E+07      3.799E+07 :   0.18480        0.24328       0.22204      :   0.18479        0.24327        0.22204    :
+ :       1 :    1.464E+06      1.608E+06 :   0.02280        0.03069       0.02795      :         0              0              0    :
+ :       2 :    5.735E+06      6.204E+06 :   0.21872        0.28268       0.26131      :   0.17063        0.22053        0.20386    :
+ :       3 :    1.865E+06      2.037E+06 :   0.29246        0.38613       0.35362      :   0.50482        0.66652        0.61040    :
+ :       4 :    1.659E+05      2.936E+05 :   0.04104        0.08447       0.04772      :         0              0              0    :
+ :       5 :    7.773E+05      8.642E+05 :   0.02358        0.03199       0.02877      :   0.13699        0.18586        0.16716    :
+ :       6 :    5.619E+06      6.139E+06 :   0.19055        0.24889       0.22781      :   0.19467        0.25428        0.23274    :
+ :       7 :    0.000E+00      0.000E+00 :                                             :                                            :
+ :       8 :    2.984E+05      3.384E+05 :  -0.06158       -0.09135      -0.08054      :         0              0              0    :
+ :       9 :    2.613E+06      2.859E+06 :   0.18640        0.24738       0.22610      :         0              0              0    :
+ :      10 :    8.101E+05      9.000E+05 :   0.15034        0.20765       0.18689      :         0              0              0    :
+ :      11 :    2.426E+05      3.463E+05 :   0.00724        0.01344       0.00941      :         0              0              0    :
+ :      12 :    6.806E+05      7.415E+05 :   0.06343        0.08265       0.07587      :   0.07244        0.09438        0.08663    :
+ :      13 :    3.885E+06      4.220E+06 :   0.22475        0.29179       0.26859      :   0.22130        0.28732        0.26447    :
+ :      14 :    0.000E+00      0.000E+00 :                                             :                                            :
+ :      15 :    2.836E+04      3.076E+04 :  -0.31316       -0.40709      -0.37532      :         0        0.00000        0.00000    :
+ :      16 :    3.251E+06      3.546E+06 :   0.11881        0.15614       0.14314      :         0              0              0    :
+ :      17 :    2.645E+05      2.934E+05 :   0.06912        0.09374       0.08449      :         0              0              0    :
+ :      18 :    5.443E+05      5.977E+05 :  -0.08233       -0.10763      -0.09801      :         0              0              0    :
+ :      19 :    9.198E+05      1.002E+06 :   0.25716        0.33594       0.30827      :   1.26821        1.65674        1.52027    :
+ :      20 :    5.505E+06      5.963E+06 :   0.26326        0.33802       0.31206      :   0.23323        0.29947        0.27647    :
+ :      21 :    0.000E+00      0.000E+00 :                                             :                                            :
+ ====================================================================================================================================
+
+ @--MESSAGE  AT TIME      912.0   DAYS    ( 1-JLY-2020):
+ @           RESTART FILE WRITTEN   REPORT    82                             
+ @           RESTART INCLUDES INTERBLOCK FLOWS                               
+ @                            PHASE RESERVOIR DENSITIES                      
+   500 READING END     
+1                             **********************************************************************  87
+  END      AT    912.00  DAYS * Drogon synthetic reservoir model                                       * ECLIPSE  VERSION 2025.1     
+  REPORT  82     1 JLY 2020   *  RUN                                                                   * RUN AT 09:10 ON 28 MAY 2025 
+                              **************************************************************************
+          237 Mbytes of storage required                         
+       3.4072 KB/active cell                                     
+          673 Mbytes (image size)                                
+
+ Error summary 
+ Comments               3
+ Warnings              25
+ Problems               0
+ Errors                 0
+ Bugs                   0
+ Final cpu     265.41 elapsed     277.35
+ Total number of time steps forced to be accepted          0

--- a/tests/testdata_prtvol2csv/DROGON_NO_INITIAL_BALANCE_FLOW.PRT
+++ b/tests/testdata_prtvol2csv/DROGON_NO_INITIAL_BALANCE_FLOW.PRT
@@ -1,0 +1,4089 @@
+
+
+
+ ########  #          ######   #           #
+ #         #         #      #   #         # 
+ #####     #         #      #    #   #   #  
+ #         #         #      #     # # # #   
+ #         #######    ######       #   #    
+
+Flow is a simulator for fully implicit three-phase black-oil flow, and is part of OPM.
+For more information visit: https://opm-project.org 
+
+Flow Version     =  2025.10-pre (9020fed6b)
+Machine name     =  st-lintgx0044.st.statoil.no (Number of logical cores: 10, Memory size: 152591.55 MB) 
+Operating system =  Linux x86_64 (Kernel: 4.18.0-553.53.1.el8_10.x86_64, #1 SMP Fri May 9 17:36:31 EDT 2025 )
+Build time       =  2025-06-18 at 18:07:16 hrs
+User             =  lilbe
+Simulation started on 19-06-2025 at 10:53:22 hrs
+Using 1 MPI processes with 1 OMP threads on each 
+Parameters used by Flow:
+# [known parameters which were specified at run-time]
+ThreadsPerProcess="1" # default: "2"
+EnableEsmry="true" # default: "0"
+EclDeckFileName="DROGON_NO_INITIAL_FLOW-99.DATA" # default: ""
+# [parameters which were specified at compile-time]
+AcceleratorMode="none"
+ActionParsingStrictness="normal"
+AddCorners="0"
+AllowDistributedWells="0"
+AllowSplittingInactiveWells="1"
+AlternativeWellRateInit="1"
+CheckGroupConstraintsInnerWellIterations="1"
+CheckSatfuncConsistency="1"
+ContinueOnConvergenceError="0"
+ConvergenceMonitoring="0"
+ConvergenceMonitoringCutOff="6"
+ConvergenceMonitoringDecayFactor="0.75"
+CprReuseInterval="30"
+CprReuseSetup="4"
+DbhpMaxRel="1"
+DebugEmitCellPartition="0"
+DpMaxRel="0.3"
+DsMax="0.2"
+DwellFractionMax="0.2"
+EclOutputDoublePrecision="0"
+EclOutputInterval="-1"
+EdgeWeightsMethod="transmissibility"
+EnableAdaptiveTimeStepping="1"
+EnableAsyncEclOutput="1"
+EnableAsyncVtkOutput="1"
+EnableDriftCompensation="0"
+EnableDryRun="auto"
+EnableEclOutput="1"
+EnableGravity="1"
+EnableGridAdaptation="0"
+EnableIntensiveQuantityCache="1"
+EnableLoggingFalloutWarning="0"
+EnableOpmRstFile="0"
+EnableStorageCache="1"
+EnableTerminalOutput="1"
+EnableThermodynamicHints="0"
+EnableTuning="0"
+EnableVtkOutput="0"
+EnableWellOperabilityCheck="1"
+EnableWellOperabilityCheckIter="0"
+EnableWriteAllSolutions="0"
+EndTime="1e+100"
+ExplicitRockCompaction="0"
+ExternalPartition=""
+ForceDisableFluidInPlaceOutput="0"
+ForceDisableResvFluidInPlaceOutput="0"
+FullTimeStepInitially="0"
+GpuDeviceId="0"
+IgnoreKeywords=""
+IluFillinLevel="0"
+IluRedblack="0"
+IluRelaxation="0.9"
+IluReorderSpheres="0"
+ImbalanceTol="1.1"
+InitialTimeStepInDays="1"
+InitialTimeStepSize="86400"
+InjMultDampMult="0.9"
+InjMultMinDampFactor="0.05"
+InjMultOscThreshold="0.1"
+InputSkipMode="100"
+LinearSolver="cprw"
+LinearSolverIgnoreConvergenceFailure="0"
+LinearSolverMaxIter="200"
+LinearSolverPrintJsonDefinition="1"
+LinearSolverReduction="0.01"
+LinearSolverRestart="40"
+LinearSolverVerbosity="0"
+LoadFile=""
+LoadStep="-1"
+LocalDomainsOrderingMeasure="maxpressure"
+LocalDomainsPartitionWellNeighborLevels="1"
+LocalDomainsPartitioningImbalance="1.03"
+LocalDomainsPartitioningMethod="zoltan"
+LocalSolveApproach="gauss-seidel"
+LocalToleranceScalingCnv="0.1"
+LocalToleranceScalingMb="1"
+LocalWellSolveControlSwitching="1"
+MatrixAddWellContributions="0"
+MaxInnerIterMsWells="100"
+MaxInnerIterWells="50"
+MaxLocalSolveIterations="20"
+MaxNewtonIterationsWithInnerWellIterations="8"
+MaxPressureChangeMsWells="1e+06"
+MaxResidualAllowed="1e+07"
+MaxSinglePrecisionDays="20"
+MaxTemperatureChange="5"
+MaxTimeStepDivisions="10"
+MaxTimeStepSize="inf"
+MaxWelleqIter="30"
+MaximumNumberOfGroupSwitches="3"
+MaximumNumberOfWellSwitches="3"
+MaximumWaterSaturation="1"
+MetisParams="default"
+MiluVariant="ILU"
+MinStrictCnvIter="-1"
+MinStrictMbIter="-1"
+MinTimeStepBasedOnNewtonIterations="0"
+MinTimeStepBeforeShuttingProblematicWellsInDays="0.01"
+MinTimeStepSize="0"
+NetworkMaxOuterIterations="10"
+NetworkMaxPressureUpdateInBars="5"
+NetworkMaxStrictOuterIterations="10"
+NetworkMaxSubIterations="20"
+NetworkPressureUpdateDampingFactor="0.1"
+NewtonMaxError="1e+100"
+NewtonMaxIterations="20"
+NewtonMaxRelax="0.5"
+NewtonMinIterations="2"
+NewtonRelaxationType="dampen"
+NewtonTargetIterations="10"
+NewtonTolerance="0.01"
+NewtonVerbose="1"
+NewtonWriteConvergence="0"
+NlddLocalLinearSolver="ilu0"
+NlddLocalLinearSolverMaxIter="200"
+NlddLocalLinearSolverReduction="0.01"
+NlddNumInitialNewtonIter="1"
+NonlinearSolver="newton"
+NumLocalDomains="0"
+NumOverlap="1"
+NumPressurePointsEquil="2000"
+NumSatfuncConsistencySamplePoints="5"
+NupcolGroupRateTolerance="0.001"
+OpenclIluParallel="1"
+OpenclPlatformId="0"
+OutputDir=""
+OutputExtraConvergenceInfo="none"
+OutputInterval="1"
+OutputMode="all"
+OwnerCellsFirst="1"
+ParameterFile=""
+ParsingStrictness="normal"
+PartitionMethod="zoltanwell"
+PreSolveNetwork="1"
+PredeterminedTimeStepsFile=""
+PressureMax="1e+99"
+PressureMin="-1e+99"
+PressureScale="1"
+PriVarOscilationThreshold="1e-05"
+PrintParameters="2"
+ProjectSaturations="0"
+RegularizationFactorWells="100"
+RelaxedLinearSolverReduction="0.01"
+RelaxedMaxPvFraction="0.03"
+RelaxedPressureTolMsw="10000"
+RelaxedWellFlowTol="0.001"
+RestartTime="-1e+35"
+RestartWritingInterval="16777215"
+SaveFile=""
+SaveStep=""
+ScaleLinearSystem="0"
+SchedRestart="0"
+SerialPartitioning="0"
+ShutUnsolvableWells="1"
+Slave="0"
+SolveWelleqInitially="1"
+SolverContinueOnConvergenceFailure="0"
+SolverGrowthFactor="2"
+SolverMaxGrowth="3"
+SolverMaxRestarts="10"
+SolverMaxTimeStepInDays="365"
+SolverMinTimeStep="1e-12"
+SolverRestartFactor="0.33"
+SolverVerbosity="1"
+StrictInnerIterWells="40"
+StrictOuterIterWells="6"
+TemperatureMax="1e+09"
+TemperatureMin="0"
+TimeStepAfterEventInDays="-1"
+TimeStepControl="pid+newtoniteration"
+TimeStepControlDecayDampingFactor="1"
+TimeStepControlDecayRate="0.75"
+TimeStepControlFileName="timesteps"
+TimeStepControlGrowthDampingFactor="3.2"
+TimeStepControlGrowthRate="1.25"
+TimeStepControlMaxReductionTimeStep="0.1"
+TimeStepControlParameters="0.125;0.25;0.125;0.75;0.25"
+TimeStepControlRejectCompletedStep="0"
+TimeStepControlSafetyFactor="0.8"
+TimeStepControlTargetIterations="30"
+TimeStepControlTargetNewtonIterations="8"
+TimeStepControlTolerance="0.1"
+TimeStepControlToleranceTestVersion="standard"
+TimeStepVerbosity="1"
+ToleranceCnv="0.01"
+ToleranceCnvEnergy="0.01"
+ToleranceCnvEnergyRelaxed="1"
+ToleranceCnvRelaxed="1"
+ToleranceEnergyBalance="1e-07"
+ToleranceEnergyBalanceRelaxed="1e-06"
+ToleranceMb="1e-07"
+ToleranceMbRelaxed="1e-06"
+TolerancePressureMsWells="1000"
+ToleranceWellControl="1e-07"
+ToleranceWells="0.0001"
+UpdateEquationsScaling="0"
+UseAverageDensityMsWells="0"
+UseGmres="0"
+UseImplicitIpr="1"
+UseMultisegmentWell="1"
+UseUpdateStabilization="1"
+VtkWriteAverageMolarMasses="0"
+VtkWriteDensities="1"
+VtkWriteDiffusionCoefficients="0"
+VtkWriteDofIndex="0"
+VtkWriteEffectiveDiffusionCoefficients="0"
+VtkWriteExtrusionFactor="0"
+VtkWriteFilterVelocities="0"
+VtkWriteFugacities="0"
+VtkWriteFugacityCoeffs="0"
+VtkWriteGasDissolutionFactor="0"
+VtkWriteGasFormationVolumeFactor="0"
+VtkWriteGasSaturationPressure="0"
+VtkWriteIntrinsicPermeabilities="0"
+VtkWriteMassFractions="0"
+VtkWriteMobilities="0"
+VtkWriteMolarities="0"
+VtkWriteMoleFractions="1"
+VtkWriteOilFormationVolumeFactor="0"
+VtkWriteOilSaturationPressure="0"
+VtkWriteOilVaporizationFactor="0"
+VtkWritePorosity="1"
+VtkWritePotentialGradients="0"
+VtkWritePressures="1"
+VtkWritePrimaryVars="0"
+VtkWritePrimaryVarsMeaning="0"
+VtkWriteProcessRank="0"
+VtkWriteRelativePermeabilities="1"
+VtkWriteSaturatedGasOilVaporizationFactor="0"
+VtkWriteSaturatedOilGasDissolutionFactor="0"
+VtkWriteSaturationRatios="0"
+VtkWriteSaturations="1"
+VtkWriteTemperature="1"
+VtkWriteTortuosities="0"
+VtkWriteTotalMassFractions="0"
+VtkWriteTotalMoleFractions="0"
+VtkWriteTracerConcentration="0"
+VtkWriteViscosities="0"
+VtkWriteWaterFormationVolumeFactor="0"
+WaterOnlyThreshold="1"
+WellGroupConstraintsMaxIterations="1"
+ZoltanImbalanceTol="1.1"
+ZoltanParams="graph"
+ZoltanPhgEdgeSizeThreshold="0.35"
+
+Reading deck file 'DROGON_NO_INITIAL_FLOW-99.DATA'
+    0 Reading RUNSPEC  in DROGON_NO_INITIAL_FLOW-99.DATA line 11
+    1 Reading TITLE    in DROGON_NO_INITIAL_FLOW-99.DATA line 15
+    2 Reading START    in DROGON_NO_INITIAL_FLOW-99.DATA line 19
+    3 Reading OIL      in DROGON_NO_INITIAL_FLOW-99.DATA line 23
+    4 Reading GAS      in DROGON_NO_INITIAL_FLOW-99.DATA line 24
+    5 Reading WATER    in DROGON_NO_INITIAL_FLOW-99.DATA line 25
+    6 Reading DISGAS   in DROGON_NO_INITIAL_FLOW-99.DATA line 26
+    7 Reading VAPOIL   in DROGON_NO_INITIAL_FLOW-99.DATA line 27
+    8 Reading METRIC   in DROGON_NO_INITIAL_FLOW-99.DATA line 30
+    9 Reading CPR      in DROGON_NO_INITIAL_FLOW-99.DATA line 32
+   10 Reading EQLOPTS  in DROGON_NO_INITIAL_FLOW-99.DATA line 36
+   11 Reading TRACERS  in DROGON_NO_INITIAL_FLOW-99.DATA line 41
+   12 Reading DIMENS   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/runspec/drogon.dimens line 2
+   13 Reading TABDIMS  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/runspec/drogon.tabdims line 2
+   14 Reading EQLDIMS  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/runspec/drogon.eqldims line 2
+   15 Reading REGDIMS  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/runspec/drogon.regdims line 2
+   16 Reading GRIDOPTS in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/runspec/drogon.gridopts line 2
+   17 Reading FAULTDIM in DROGON_NO_INITIAL_FLOW-99.DATA line 65
+   18 Reading WELLDIMS in DROGON_NO_INITIAL_FLOW-99.DATA line 73
+   19 Reading WSEGDIMS in DROGON_NO_INITIAL_FLOW-99.DATA line 81
+   20 Reading VFPPDIMS in DROGON_NO_INITIAL_FLOW-99.DATA line 92
+   21 Reading UNIFIN   in DROGON_NO_INITIAL_FLOW-99.DATA line 97
+   22 Reading UNIFOUT  in DROGON_NO_INITIAL_FLOW-99.DATA line 98
+   23 Reading MESSAGES in DROGON_NO_INITIAL_FLOW-99.DATA line 104
+   24 Reading GRID     in DROGON_NO_INITIAL_FLOW-99.DATA line 109
+   25 Reading NOECHO   in DROGON_NO_INITIAL_FLOW-99.DATA line 111
+   26 Reading NEWTRAN  in DROGON_NO_INITIAL_FLOW-99.DATA line 113
+   27 Reading GRIDFILE in DROGON_NO_INITIAL_FLOW-99.DATA line 115
+   28 Reading INIT     in DROGON_NO_INITIAL_FLOW-99.DATA line 118
+   29 Reading PINCH    in DROGON_NO_INITIAL_FLOW-99.DATA line 121
+   30 Reading IMPORT   in DROGON_NO_INITIAL_FLOW-99.DATA line 124
+   31 Loading MAPAXES  from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.grid
+      Skipping SPECGRID from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.grid
+   32 Loading COORD    from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.grid
+   33 Loading ZCORN    from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.grid
+   34 Loading ACTNUM   from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.grid
+   34 Reading FAULTS   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.faults line 10
+   35 Reading IMPORT   in DROGON_NO_INITIAL_FLOW-99.DATA line 130
+   36 Loading PORO     from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.poro
+   36 Reading IMPORT   in DROGON_NO_INITIAL_FLOW-99.DATA line 133
+   37 Loading PERMX    from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.perm
+   38 Loading PERMY    from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.perm
+   39 Loading PERMZ    from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.perm
+   39 Reading MULTNUM  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.multnum line 13
+   40 Reading MULTREGT in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.multregt line 4
+   41 Reading EDIT     in DROGON_NO_INITIAL_FLOW-99.DATA line 146
+   42 Reading MULTIPLY in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 10
+   43 Reading EDITNNC  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440
+   44 Reading PROPS    in DROGON_NO_INITIAL_FLOW-99.DATA line 154
+   45 Reading FILLEPS  in DROGON_NO_INITIAL_FLOW-99.DATA line 157
+   46 Reading SWOF     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/props/drogon.sattab line 1
+   47 Reading SGOF     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/props/drogon.sattab line 563
+   48 Reading IMPORT   in DROGON_NO_INITIAL_FLOW-99.DATA line 162
+   49 Loading SWATINIT from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/props/drogon.swatinit
+   49 Reading IMPORT   in DROGON_NO_INITIAL_FLOW-99.DATA line 165
+   50 Loading SWL      from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/props/drogon.swl
+   50 Reading IMPORT   in DROGON_NO_INITIAL_FLOW-99.DATA line 168
+   51 Loading SWCR     from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/props/drogon.swcr
+   51 Reading IMPORT   in DROGON_NO_INITIAL_FLOW-99.DATA line 171
+   52 Loading SGU      from IMPORT file /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/props/drogon.sgu
+   52 Reading ROCKOPTS in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/props/drogon.pvt line 4
+   53 Reading ROCK     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/props/drogon.pvt line 7
+   54 Reading PVTW     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/props/drogon.pvt line 12
+   55 Reading DENSITY  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/props/drogon.pvt line 16
+   56 Reading PVTO     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/props/drogon.pvt line 21
+   57 Reading PVTG     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/props/drogon.pvt line 378
+   58 Reading TRACER   in DROGON_NO_INITIAL_FLOW-99.DATA line 178
+   59 Reading EXTRAPMS in DROGON_NO_INITIAL_FLOW-99.DATA line 183
+   60 Reading REGIONS  in DROGON_NO_INITIAL_FLOW-99.DATA line 187
+   61 Reading EQLNUM   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/regions/drogon.eqlnum line 5
+   62 Reading FIPNUM   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/regions/drogon.fipnum line 5
+   63 Reading FIPZON   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/regions/drogon.fipzon line 10
+   64 Reading SATNUM   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/regions/drogon.satnum line 5
+   65 Reading PVTNUM   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/regions/drogon.pvtnum line 5
+   66 Reading SOLUTION in DROGON_NO_INITIAL_FLOW-99.DATA line 207
+   67 Reading EQUIL    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/solution/drogon.equil line 1
+   68 Reading RSVD     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/solution/drogon.rxvd line 1
+   69 Reading RVVD     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/solution/drogon.rxvd line 17
+   70 Reading THPRES   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/solution/drogon.thpres line 2
+   71 Reading TVDPFWT1 in DROGON_NO_INITIAL_FLOW-99.DATA line 219
+   72 Reading TVDPFWT2 in DROGON_NO_INITIAL_FLOW-99.DATA line 224
+   73 Reading RPTSOL   in DROGON_NO_INITIAL_FLOW-99.DATA line 228
+   74 Reading RPTRST   in DROGON_NO_INITIAL_FLOW-99.DATA line 234
+   75 Reading SUMMARY  in DROGON_NO_INITIAL_FLOW-99.DATA line 239
+   76 Reading SUMTHIN  in DROGON_NO_INITIAL_FLOW-99.DATA line 244
+   77 Reading FOPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 7
+   78 Reading FOPRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 8
+   79 Reading FGPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 9
+   80 Reading FGPRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 10
+   81 Reading FWPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 11
+   82 Reading FWPRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 12
+   83 Reading FLPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 13
+   84 Reading FLPRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 14
+   85 Reading FVPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 15
+   86 Reading FOPRF    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 16
+   87 Reading FOPRS    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 17
+   88 Reading FGSR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 18
+   89 Reading FGPRF    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 19
+   90 Reading FGPRS    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 20
+   91 Reading FOPP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 24
+   92 Reading FWPP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 25
+   93 Reading FGPP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 26
+   94 Reading FMWPR    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 30
+   95 Reading FMWIN    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 31
+   96 Reading FVIR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 33
+   97 Reading FWIR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 34
+   98 Reading FWIRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 35
+   99 Reading FGIR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 36
+  100 Reading FGIRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 37
+  101 Reading FGLIR    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 39
+  102 Reading FMCTP    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 43
+  103 Reading FVPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 48
+  104 Reading FOPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 49
+  105 Reading FOPTH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 50
+  106 Reading FWPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 51
+  107 Reading FWPTH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 52
+  108 Reading FGPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 53
+  109 Reading FGPTH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 54
+  110 Reading FWIT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 55
+  111 Reading FWITH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 56
+  112 Reading FGIT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 57
+  113 Reading FGITH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 58
+  114 Reading FOPTF    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 59
+  115 Reading FOPTS    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 60
+  116 Reading FWIP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 64
+  117 Reading FOIP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 65
+  118 Reading FGIP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 66
+  119 Reading FWCT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 68
+  120 Reading FWCTH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 69
+  121 Reading FGOR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 70
+  122 Reading FGORH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 71
+  123 Reading FGLR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 72
+  124 Reading FWGR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 73
+  125 Reading FPR      in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 75
+  126 Reading RPR      in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 77
+  127 Reading ROIP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 79
+  128 Reading ROE      in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 81
+  129 Reading ROIPL    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 83
+  130 Reading ROIPG    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 85
+  131 Reading RGIP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 87
+  132 Reading RGIPL    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 89
+  133 Reading RGIPG    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 91
+  134 Reading RGPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 93
+  135 Reading RGPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 95
+  136 Reading GMWPR    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 100
+  137 Reading GMWIN    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 102
+  138 Reading GGLIR    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 104
+  139 Reading GOPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 106
+  140 Reading GOPRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 108
+  141 Reading GGPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 110
+  142 Reading GGPRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 112
+  143 Reading GWPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 114
+  144 Reading GWPRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 116
+  145 Reading GVPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 118
+  146 Reading GLPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 120
+  147 Reading GOPRF    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 122
+  148 Reading GOPRS    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 124
+  149 Reading GGPRF    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 126
+  150 Reading GGPRS    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 128
+  151 Reading GWCT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 130
+  152 Reading GWCTH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 132
+  153 Reading GGOR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 134
+  154 Reading GGORH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 136
+  155 Reading GWGR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 138
+  156 Reading GGLR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 140
+  157 Reading GOPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 142
+  158 Reading GOPTH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 144
+  159 Reading GGPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 146
+  160 Reading GGPTH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 148
+  161 Reading GWPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 150
+  162 Reading GWPTH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 152
+  163 Reading GVPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 154
+  164 Reading GLPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 156
+  165 Reading GOPTF    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 158
+  166 Reading GOPTS    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 160
+  167 Reading GGPTF    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 162
+  168 Reading GGPTS    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 164
+  169 Reading GWIR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 166
+  170 Reading GVIR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 168
+  171 Reading GWIRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 170
+  172 Reading GGIR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 172
+  173 Reading GGIRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 174
+  174 Reading GPR      in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 176
+  175 Reading GOPP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 179
+  176 Reading GGPP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 181
+  177 Reading GWPP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 183
+  178 Reading GMCTP    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 188
+  179 Reading WOPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 193
+  180 Reading WOPRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 195
+  181 Reading WGPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 197
+  182 Reading WGPRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 199
+  183 Reading WWPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 201
+  184 Reading WWPRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 203
+  185 Reading WLPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 205
+  186 Reading WLPRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 207
+  187 Reading WOPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 210
+  188 Reading WWPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 212
+  189 Reading WGPT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 214
+  190 Reading WOPTH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 216
+  191 Reading WWPTH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 218
+  192 Reading WGPTH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 220
+  193 Reading WWCT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 223
+  194 Reading WWCTH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 225
+  195 Reading WGOR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 227
+  196 Reading WGORH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 229
+  197 Reading WWIR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 231
+  198 Reading WWIRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 233
+  199 Reading WGIR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 235
+  200 Reading WGIRH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 237
+  201 Reading WWIT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 239
+  202 Reading WWITH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 241
+  203 Reading WGIT     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 243
+  204 Reading WGITH    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 245
+  205 Reading WBHP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 248
+  206 Reading WTHP     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 250
+  207 Reading WPI      in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 252
+  208 Reading WVPR     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 254
+  209 Reading WBP      in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 256
+  210 Reading WBP4     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 258
+  211 Reading WBP9     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 260
+  212 Reading WMCTL    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 262
+  213 Reading WSTAT    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 264
+  214 Reading WGLIR    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 267
+  215 Reading WOGLR    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 272
+  216 Reading WTPRWT1  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 278
+  217 Reading WTPRWT2  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 280
+  218 Reading WTPTWT1  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 283
+  219 Reading WTPTWT2  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 285
+  220 Reading WTPCWT1  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 288
+  221 Reading WTPCWT2  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 290
+  222 Reading WTIRWT1  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 293
+  223 Reading WTIRWT2  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 295
+  224 Reading WTITWT1  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 298
+  225 Reading WTITWT2  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 300
+  226 Reading WTICWT1  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 303
+  227 Reading WTICWT2  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 305
+  228 Reading TCPU     in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 317
+  229 Reading TCPUDAY  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 318
+  230 Reading WOPRL    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 322
+  231 Reading WWPRL    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 336
+  232 Reading WGPRL    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 350
+  233 Reading WWIRL    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 364
+  234 Reading SCHEDULE in DROGON_NO_INITIAL_FLOW-99.DATA line 252
+  235 Reading VFPPROD  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/vfp/A-1.inc line 89
+  236 Reading VFPPROD  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/vfp/A-2.inc line 89
+  237 Reading VFPPROD  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/vfp/A-3.inc line 89
+  238 Reading VFPPROD  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/vfp/A-4.inc line 90
+  239 Reading WELSPECS in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 9
+  240 Reading COMPORD  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 18
+  241 Reading GRUPTREE in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 26
+  242 Reading COMPDAT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 32
+  243 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 164
+  244 Reading WRFTPLT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 173
+  245 Reading TUNING   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 182
+  246 Reading RPTRST   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 190
+  247 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 193
+  248 Reading WELSPECS in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 197
+  249 Reading COMPORD  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 202
+  250 Reading COMPDAT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 206
+  251 Reading COMPLUMP in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 233
+  252 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 258
+  253 Reading WELTARG  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 263
+  254 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 267
+  255 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 271
+  256 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 276
+  257 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 280
+  258 Reading WRFTPLT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 285
+  259 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 290
+  260 Reading WELSPECS in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 294
+  261 Reading COMPORD  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 299
+  262 Reading COMPDAT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 303
+  263 Reading COMPLUMP in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 317
+  264 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 329
+  265 Reading WELTARG  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 335
+  266 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 339
+  267 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 343
+  268 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 349
+  269 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 353
+  270 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 359
+  271 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 363
+  272 Reading WRFTPLT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 369
+  273 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 374
+  274 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 378
+  275 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 384
+  276 Reading WELSPECS in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 388
+  277 Reading COMPORD  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 393
+  278 Reading COMPDAT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 397
+  279 Reading COMPLUMP in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 428
+  280 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 457
+  281 Reading WCONINJH in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 463
+  282 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 468
+  283 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 472
+  284 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 478
+  285 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 482
+  286 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 488
+  287 Reading WTRACER  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 493
+  288 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 498
+  289 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 504
+  290 Reading WTRACER  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 508
+  291 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 513
+  292 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 519
+  293 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 523
+  294 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 529
+  295 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 533
+  296 Reading RPTSCHED in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 539
+  297 Reading RPTRST   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 542
+  298 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 545
+  299 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 549
+  300 Reading RPTSCHED in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 555
+  301 Reading RPTRST   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 558
+  302 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 561
+  303 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 565
+  304 Reading WRFTPLT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 571
+  305 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 576
+  306 Reading WELSPECS in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 580
+  307 Reading COMPORD  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 585
+  308 Reading COMPDAT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 589
+  309 Reading COMPLUMP in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 618
+  310 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 645
+  311 Reading WELTARG  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 652
+  312 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 656
+  313 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 660
+  314 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 667
+  315 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 671
+  316 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 678
+  317 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 682
+  318 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 689
+  319 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 693
+  320 Reading WRFTPLT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 700
+  321 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 705
+  322 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 709
+  323 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 716
+  324 Reading WELSPECS in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 720
+  325 Reading COMPORD  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 725
+  326 Reading COMPDAT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 729
+  327 Reading COMPLUMP in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 761
+  328 Reading WELSEGS  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 791
+  329 Reading WSEGVALV in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 850
+  330 Reading COMPSEGS in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 881
+  331 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 912
+  332 Reading WELTARG  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 920
+  333 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 924
+  334 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 928
+  335 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 936
+  336 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 940
+  337 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 948
+  338 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 952
+  339 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 960
+  340 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 964
+  341 Reading WRFTPLT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 972
+  342 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 977
+  343 Reading WELSPECS in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 981
+  344 Reading COMPORD  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 986
+  345 Reading COMPDAT  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 990
+  346 Reading COMPLUMP in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1019
+  347 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1046
+  348 Reading WCONINJH in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1054
+  349 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1059
+  350 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1063
+  351 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1071
+  352 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1075
+  353 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1083
+  354 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1087
+  355 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1095
+  356 Reading WTRACER  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1100
+  357 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1105
+  358 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1113
+  359 Reading WTRACER  in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1117
+  360 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1122
+  361 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1130
+  362 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1134
+  363 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1142
+  364 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1146
+  365 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1154
+  366 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1158
+  367 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1166
+  368 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1170
+  369 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1178
+  370 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1182
+  371 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1190
+  372 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1194
+  373 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1202
+  374 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1206
+  375 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1214
+  376 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1218
+  377 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1226
+  378 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1230
+  379 Reading WCONINJH in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1238
+  380 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1244
+  381 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1248
+  382 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1252
+  383 Reading WCONINJH in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1260
+  384 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1266
+  385 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1270
+  386 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1278
+  387 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1282
+  388 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1290
+  389 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1294
+  390 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1302
+  391 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1306
+  392 Reading RPTSCHED in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1314
+  393 Reading RPTRST   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1317
+  394 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1320
+  395 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1324
+  396 Reading RPTSCHED in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1332
+  397 Reading RPTRST   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1335
+  398 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1338
+  399 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1342
+  400 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1350
+  401 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1354
+  402 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1362
+  403 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1366
+  404 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1374
+  405 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1378
+  406 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1386
+  407 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1390
+  408 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1398
+  409 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1402
+  410 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1410
+  411 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1414
+  412 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1422
+  413 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1426
+  414 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1434
+  415 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1438
+  416 Reading WCONINJH in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1446
+  417 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1452
+  418 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1456
+  419 Reading WCONINJH in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1464
+  420 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1470
+  421 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1474
+  422 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1482
+  423 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1486
+  424 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1494
+  425 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1498
+  426 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1506
+  427 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1510
+  428 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1518
+  429 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1522
+  430 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1530
+  431 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1534
+  432 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1542
+  433 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1546
+  434 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1554
+  435 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1558
+  436 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1566
+  437 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1570
+  438 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1578
+  439 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1582
+  440 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1590
+  441 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1594
+  442 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1602
+  443 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1606
+  444 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1614
+  445 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1618
+  446 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1626
+  447 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1630
+  448 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1638
+  449 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1642
+  450 Reading WCONINJH in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1650
+  451 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1656
+  452 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1660
+  453 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1664
+  454 Reading WCONINJH in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1672
+  455 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1678
+  456 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1682
+  457 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1690
+  458 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1694
+  459 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1702
+  460 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1706
+  461 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1714
+  462 Reading WCONHIST in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1718
+  463 Reading RPTSCHED in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1726
+  464 Reading RPTRST   in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1729
+  465 Reading DATES    in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 1732
+
+Warning: Unsupported keywords or keyword items:
+
+  MESSAGES: invalid value '1000000' for item 9
+  In file: DROGON_NO_INITIAL_FLOW-99.DATA, line 104
+  MESSAGES(STOPWARN): option is not supported
+
+  MESSAGES: invalid value '7000' for item 10
+  In file: DROGON_NO_INITIAL_FLOW-99.DATA, line 104
+  MESSAGES(STOPPROB): option is not supported
+
+  MESSAGES: invalid value '1' for item 11
+  In file: DROGON_NO_INITIAL_FLOW-99.DATA, line 104
+  MESSAGES(STOPERRS): option is not supported
+
+  NOECHO: keyword not supported
+  In file: DROGON_NO_INITIAL_FLOW-99.DATA, line 111
+
+  EXTRAPMS: keyword not supported
+  In file: DROGON_NO_INITIAL_FLOW-99.DATA, line 183
+
+  RPTSOL: keyword not supported
+  In file: DROGON_NO_INITIAL_FLOW-99.DATA, line 228
+
+Creating corner-point grid from keywords COORD, ZCORN and others
+
+Initializing tracers from TRACER in DROGON_NO_INITIAL_FLOW-99.DATA line 178
+Non-default tracer unit [g] from TRACER in DROGON_NO_INITIAL_FLOW-99.DATA line 178
+Loading tracer concentration from TVDPFWT1 in DROGON_NO_INITIAL_FLOW-99.DATA line 219
+Non-default tracer unit [g] from TRACER in DROGON_NO_INITIAL_FLOW-99.DATA line 178
+Reporting limit reached for Tracer tables - see PRT file for additional messages
+Loading tracer concentration from TVDPFWT2 in DROGON_NO_INITIAL_FLOW-99.DATA line 224
+3 fluid phases are active
+
+Loading faults from FAULTS in /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/grid/drogon.faults line 10
+
+Warning: Error in keyword RPTSOL, unrecognized mnemonic THPRES
+In DROGON_NO_INITIAL_FLOW-99.DATA line 228.
+
+Processing dynamic information from
+DROGON_NO_INITIAL_FLOW-99.DATA line 252
+Initializing report step 0/82 at 2018-01-01 0 DAYS line 252
+Reading from: /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/vfp/A-1.inc line 89
+Processing keyword VFPPROD at line 89
+Reading from: /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/vfp/A-2.inc line 89
+Processing keyword VFPPROD at line 89
+Reading from: /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/vfp/A-3.inc line 89
+Processing keyword VFPPROD at line 89
+Reading from: /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/vfp/A-4.inc line 90
+Processing keyword VFPPROD at line 90
+Reading from: /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 9
+Processing keyword WELSPECS at line 9
+Processing keyword COMPORD at line 18
+Processing keyword GRUPTREE at line 26
+Processing keyword COMPDAT at line 32
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 32
+The cell (22,30,12) in well R_A2 is not active and the connection will be ignored
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 32
+The cell (29,41,14) in well R_A3 is not active and the connection will be ignored
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 32
+The cell (29,41,17) in well R_A3 is not active and the connection will be ignored
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 32
+The cell (31,20,9) in well R_A5 is not active and the connection will be ignored
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 32
+The cell (31,20,10) in well R_A5 is not active and the connection will be ignored
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 32
+The cell (31,21,10) in well R_A5 is not active and the connection will be ignored
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 32
+The cell (17,42,18) in well R_A6 is not active and the connection will be ignored
+Processing keyword WCONHIST at line 164
+Processing keyword WRFTPLT at line 173
+Processing keyword TUNING at line 182
+Processing keyword RPTRST at line 190
+Complete report step 1 (4 DAYS) at 2018-01-05 (0 DAYS)
+
+Initializing report step 2/82 at 2018-01-05 (0 DAYS) line 193
+Processing keyword WELSPECS at line 197
+Processing keyword COMPORD at line 202
+Processing keyword COMPDAT at line 206
+Processing keyword COMPLUMP at line 233
+Processing keyword WCONHIST at line 258
+Processing keyword WELTARG at line 263
+Complete report step 2 (27 DAYS) at 2018-02-01 (4 DAYS)
+
+Initializing report step 3/82 at 2018-02-01 (4 DAYS) line 267
+Processing keyword WCONHIST at line 271
+Complete report step 3 (28 DAYS) at 2018-03-01 (31 DAYS)
+
+Initializing report step 4/82 at 2018-03-01 (31 DAYS) line 276
+Processing keyword WCONHIST at line 280
+Processing keyword WRFTPLT at line 285
+Complete report step 4 (9 DAYS) at 2018-03-10 (59 DAYS)
+
+Initializing report step 5/82 at 2018-03-10 (59 DAYS) line 290
+Processing keyword WELSPECS at line 294
+Processing keyword COMPORD at line 299
+Processing keyword COMPDAT at line 303
+Processing keyword COMPLUMP at line 317
+Processing keyword WCONHIST at line 329
+Processing keyword WELTARG at line 335
+Complete report step 5 (20 DAYS) at 2018-03-30 (68 DAYS)
+Report limit reached, see PRT-file for remaining Schedule initialization.
+
+Initializing report step 6/82 at 2018-03-30 (68 DAYS) line 339
+Processing keyword WCONHIST at line 343
+Complete report step 6 (2 DAYS) at 2018-04-01 (88 DAYS)
+
+Initializing report step 7/82 at 2018-04-01 (88 DAYS) line 349
+Processing keyword WCONHIST at line 353
+Complete report step 7 (27 DAYS) at 2018-04-28 (90 DAYS)
+
+Initializing report step 8/82 at 2018-04-28 (90 DAYS) line 359
+Processing keyword WCONHIST at line 363
+Processing keyword WRFTPLT at line 369
+Complete report step 8 (3 DAYS) at 2018-05-01 (117 DAYS)
+
+Initializing report step 9/82 at 2018-05-01 (117 DAYS) line 374
+Processing keyword WCONHIST at line 378
+Complete report step 9 (7 DAYS) at 2018-05-08 (120 DAYS)
+
+Initializing report step 10/82 at 2018-05-08 (120 DAYS) line 384
+Processing keyword WELSPECS at line 388
+Processing keyword COMPORD at line 393
+Processing keyword COMPDAT at line 397
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 397
+The cell (31,20,9) in well A5 is not active and the connection will be ignored
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 397
+The cell (31,20,10) in well A5 is not active and the connection will be ignored
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 397
+The cell (31,21,10) in well A5 is not active and the connection will be ignored
+Processing keyword COMPLUMP at line 428
+Processing keyword WCONHIST at line 457
+Processing keyword WCONINJH at line 463
+Complete report step 10 (24 DAYS) at 2018-06-01 (127 DAYS)
+
+Initializing report step 11/82 at 2018-06-01 (127 DAYS) line 468
+Processing keyword WCONHIST at line 472
+Complete report step 11 (1 DAYS) at 2018-06-02 (151 DAYS)
+
+Initializing report step 12/82 at 2018-06-02 (151 DAYS) line 478
+Processing keyword WCONHIST at line 482
+Complete report step 12 (6 DAYS) at 2018-06-08 (152 DAYS)
+
+Initializing report step 13/82 at 2018-06-08 (152 DAYS) line 488
+Processing keyword WTRACER at line 493
+Processing keyword WCONHIST at line 498
+Complete report step 13 (1 DAYS) at 2018-06-09 (158 DAYS)
+
+Initializing report step 14/82 at 2018-06-09 (158 DAYS) line 504
+Processing keyword WTRACER at line 508
+Processing keyword WCONHIST at line 513
+Complete report step 14 (13 DAYS) at 2018-06-22 (159 DAYS)
+
+Initializing report step 15/82 at 2018-06-22 (159 DAYS) line 519
+Processing keyword WCONHIST at line 523
+Complete report step 15 (8 DAYS) at 2018-06-30 (172 DAYS)
+
+Initializing report step 16/82 at 2018-06-30 (172 DAYS) line 529
+Processing keyword WCONHIST at line 533
+Processing keyword RPTSCHED at line 539
+Processing keyword RPTRST at line 542
+Complete report step 16 (1 DAYS) at 2018-07-01 (180 DAYS)
+
+Initializing report step 17/82 at 2018-07-01 (180 DAYS) line 545
+Processing keyword WCONHIST at line 549
+Processing keyword RPTSCHED at line 555
+Processing keyword RPTRST at line 558
+Complete report step 17 (2 DAYS) at 2018-07-03 (181 DAYS)
+
+Initializing report step 18/82 at 2018-07-03 (181 DAYS) line 561
+Processing keyword WCONHIST at line 565
+Processing keyword WRFTPLT at line 571
+Complete report step 18 (10 DAYS) at 2018-07-13 (183 DAYS)
+
+Initializing report step 19/82 at 2018-07-13 (183 DAYS) line 576
+Processing keyword WELSPECS at line 580
+Processing keyword COMPORD at line 585
+Processing keyword COMPDAT at line 589
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 589
+The cell (29,41,14) in well A3 is not active and the connection will be ignored
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 589
+The cell (29,41,17) in well A3 is not active and the connection will be ignored
+Processing keyword COMPLUMP at line 618
+Processing keyword WCONHIST at line 645
+Processing keyword WELTARG at line 652
+Complete report step 19 (19 DAYS) at 2018-08-01 (193 DAYS)
+
+Initializing report step 20/82 at 2018-08-01 (193 DAYS) line 656
+Processing keyword WCONHIST at line 660
+Complete report step 20 (24 DAYS) at 2018-08-25 (212 DAYS)
+
+Initializing report step 21/82 at 2018-08-25 (212 DAYS) line 667
+Processing keyword WCONHIST at line 671
+Complete report step 21 (7 DAYS) at 2018-09-01 (236 DAYS)
+
+Initializing report step 22/82 at 2018-09-01 (236 DAYS) line 678
+Processing keyword WCONHIST at line 682
+Complete report step 22 (11 DAYS) at 2018-09-12 (243 DAYS)
+
+Initializing report step 23/82 at 2018-09-12 (243 DAYS) line 689
+Processing keyword WCONHIST at line 693
+Processing keyword WRFTPLT at line 700
+Complete report step 23 (2 DAYS) at 2018-09-14 (254 DAYS)
+
+Initializing report step 24/82 at 2018-09-14 (254 DAYS) line 705
+Processing keyword WCONHIST at line 709
+Complete report step 24 (8 DAYS) at 2018-09-22 (256 DAYS)
+
+Initializing report step 25/82 at 2018-09-22 (256 DAYS) line 716
+Processing keyword WELSPECS at line 720
+Processing keyword COMPORD at line 725
+Processing keyword COMPDAT at line 729
+Processing keyword COMPLUMP at line 761
+Processing keyword WELSEGS at line 791
+Processing keyword WSEGVALV at line 850
+Processing keyword COMPSEGS at line 881
+Processing keyword WCONHIST at line 912
+Processing keyword WELTARG at line 920
+Complete report step 25 (9 DAYS) at 2018-10-01 (264 DAYS)
+
+Initializing report step 26/82 at 2018-10-01 (264 DAYS) line 924
+Processing keyword WCONHIST at line 928
+Complete report step 26 (4 DAYS) at 2018-10-05 (273 DAYS)
+
+Initializing report step 27/82 at 2018-10-05 (273 DAYS) line 936
+Processing keyword WCONHIST at line 940
+Complete report step 27 (27 DAYS) at 2018-11-01 (277 DAYS)
+
+Initializing report step 28/82 at 2018-11-01 (277 DAYS) line 948
+Processing keyword WCONHIST at line 952
+Complete report step 28 (6 DAYS) at 2018-11-07 (304 DAYS)
+
+Initializing report step 29/82 at 2018-11-07 (304 DAYS) line 960
+Processing keyword WCONHIST at line 964
+Processing keyword WRFTPLT at line 972
+Complete report step 29 (10 DAYS) at 2018-11-17 (310 DAYS)
+
+Initializing report step 30/82 at 2018-11-17 (310 DAYS) line 977
+Processing keyword WELSPECS at line 981
+Processing keyword COMPORD at line 986
+Processing keyword COMPDAT at line 990
+
+Warning: Problem with COMPDAT keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/schedule/drogon_hist_v2.sch line 990
+The cell (17,42,18) in well A6 is not active and the connection will be ignored
+Processing keyword COMPLUMP at line 1019
+Processing keyword WCONHIST at line 1046
+Processing keyword WCONINJH at line 1054
+Complete report step 30 (14 DAYS) at 2018-12-01 (320 DAYS)
+
+Initializing report step 31/82 at 2018-12-01 (320 DAYS) line 1059
+Processing keyword WCONHIST at line 1063
+Complete report step 31 (6 DAYS) at 2018-12-07 (334 DAYS)
+
+Initializing report step 32/82 at 2018-12-07 (334 DAYS) line 1071
+Processing keyword WCONHIST at line 1075
+Complete report step 32 (8 DAYS) at 2018-12-15 (340 DAYS)
+
+Initializing report step 33/82 at 2018-12-15 (340 DAYS) line 1083
+Processing keyword WCONHIST at line 1087
+Complete report step 33 (2 DAYS) at 2018-12-17 (348 DAYS)
+
+Initializing report step 34/82 at 2018-12-17 (348 DAYS) line 1095
+Processing keyword WTRACER at line 1100
+Processing keyword WCONHIST at line 1105
+Complete report step 34 (1 DAYS) at 2018-12-18 (350 DAYS)
+
+Initializing report step 35/82 at 2018-12-18 (350 DAYS) line 1113
+Processing keyword WTRACER at line 1117
+Processing keyword WCONHIST at line 1122
+Complete report step 35 (10 DAYS) at 2018-12-28 (351 DAYS)
+
+Initializing report step 36/82 at 2018-12-28 (351 DAYS) line 1130
+Processing keyword WCONHIST at line 1134
+Complete report step 36 (4 DAYS) at 2019-01-01 (361 DAYS)
+
+Initializing report step 37/82 at 2019-01-01 (361 DAYS) line 1142
+Processing keyword WCONHIST at line 1146
+Complete report step 37 (31 DAYS) at 2019-02-01 (365 DAYS)
+
+Initializing report step 38/82 at 2019-02-01 (365 DAYS) line 1154
+Processing keyword WCONHIST at line 1158
+Complete report step 38 (8 DAYS) at 2019-02-09 (396 DAYS)
+
+Initializing report step 39/82 at 2019-02-09 (396 DAYS) line 1166
+Processing keyword WCONHIST at line 1170
+Complete report step 39 (20 DAYS) at 2019-03-01 (404 DAYS)
+
+Initializing report step 40/82 at 2019-03-01 (404 DAYS) line 1178
+Processing keyword WCONHIST at line 1182
+Complete report step 40 (8 DAYS) at 2019-03-09 (424 DAYS)
+
+Initializing report step 41/82 at 2019-03-09 (424 DAYS) line 1190
+Processing keyword WCONHIST at line 1194
+Complete report step 41 (13 DAYS) at 2019-03-22 (432 DAYS)
+
+Initializing report step 42/82 at 2019-03-22 (432 DAYS) line 1202
+Processing keyword WCONHIST at line 1206
+Complete report step 42 (10 DAYS) at 2019-04-01 (445 DAYS)
+
+Initializing report step 43/82 at 2019-04-01 (445 DAYS) line 1214
+Processing keyword WCONHIST at line 1218
+Complete report step 43 (30 DAYS) at 2019-05-01 (455 DAYS)
+
+Initializing report step 44/82 at 2019-05-01 (455 DAYS) line 1226
+Processing keyword WCONHIST at line 1230
+Processing keyword WCONINJH at line 1238
+Complete report step 44 (3 DAYS) at 2019-05-04 (485 DAYS)
+
+Initializing report step 45/82 at 2019-05-04 (485 DAYS) line 1244
+Complete report step 45 (1 DAYS) at 2019-05-05 (488 DAYS)
+
+Initializing report step 46/82 at 2019-05-05 (488 DAYS) line 1248
+Processing keyword WCONHIST at line 1252
+Processing keyword WCONINJH at line 1260
+Complete report step 46 (19 DAYS) at 2019-05-24 (489 DAYS)
+
+Initializing report step 47/82 at 2019-05-24 (489 DAYS) line 1266
+Processing keyword WCONHIST at line 1270
+Complete report step 47 (8 DAYS) at 2019-06-01 (508 DAYS)
+
+Initializing report step 48/82 at 2019-06-01 (508 DAYS) line 1278
+Processing keyword WCONHIST at line 1282
+Complete report step 48 (13 DAYS) at 2019-06-14 (516 DAYS)
+
+Initializing report step 49/82 at 2019-06-14 (516 DAYS) line 1290
+Processing keyword WCONHIST at line 1294
+Complete report step 49 (16 DAYS) at 2019-06-30 (529 DAYS)
+
+Initializing report step 50/82 at 2019-06-30 (529 DAYS) line 1302
+Processing keyword WCONHIST at line 1306
+Processing keyword RPTSCHED at line 1314
+Processing keyword RPTRST at line 1317
+Complete report step 50 (1 DAYS) at 2019-07-01 (545 DAYS)
+
+Initializing report step 51/82 at 2019-07-01 (545 DAYS) line 1320
+Processing keyword WCONHIST at line 1324
+Processing keyword RPTSCHED at line 1332
+Processing keyword RPTRST at line 1335
+Complete report step 51 (26 DAYS) at 2019-07-27 (546 DAYS)
+
+Initializing report step 52/82 at 2019-07-27 (546 DAYS) line 1338
+Processing keyword WCONHIST at line 1342
+Complete report step 52 (5 DAYS) at 2019-08-01 (572 DAYS)
+
+Initializing report step 53/82 at 2019-08-01 (572 DAYS) line 1350
+Processing keyword WCONHIST at line 1354
+Complete report step 53 (15 DAYS) at 2019-08-16 (577 DAYS)
+
+Initializing report step 54/82 at 2019-08-16 (577 DAYS) line 1362
+Processing keyword WCONHIST at line 1366
+Complete report step 54 (8 DAYS) at 2019-08-24 (592 DAYS)
+
+Initializing report step 55/82 at 2019-08-24 (592 DAYS) line 1374
+Processing keyword WCONHIST at line 1378
+Complete report step 55 (8 DAYS) at 2019-09-01 (600 DAYS)
+
+Initializing report step 56/82 at 2019-09-01 (600 DAYS) line 1386
+Processing keyword WCONHIST at line 1390
+Complete report step 56 (5 DAYS) at 2019-09-06 (608 DAYS)
+
+Initializing report step 57/82 at 2019-09-06 (608 DAYS) line 1398
+Processing keyword WCONHIST at line 1402
+Complete report step 57 (25 DAYS) at 2019-10-01 (613 DAYS)
+
+Initializing report step 58/82 at 2019-10-01 (613 DAYS) line 1410
+Processing keyword WCONHIST at line 1414
+Complete report step 58 (18 DAYS) at 2019-10-19 (638 DAYS)
+
+Initializing report step 59/82 at 2019-10-19 (638 DAYS) line 1422
+Processing keyword WCONHIST at line 1426
+Complete report step 59 (13 DAYS) at 2019-11-01 (656 DAYS)
+
+Initializing report step 60/82 at 2019-11-01 (656 DAYS) line 1434
+Processing keyword WCONHIST at line 1438
+Processing keyword WCONINJH at line 1446
+Complete report step 60 (1 DAYS) at 2019-11-02 (669 DAYS)
+
+Initializing report step 61/82 at 2019-11-02 (669 DAYS) line 1452
+Processing keyword WCONHIST at line 1456
+Processing keyword WCONINJH at line 1464
+Complete report step 61 (6 DAYS) at 2019-11-08 (670 DAYS)
+
+Initializing report step 62/82 at 2019-11-08 (670 DAYS) line 1470
+Processing keyword WCONHIST at line 1474
+Complete report step 62 (8 DAYS) at 2019-11-16 (676 DAYS)
+
+Initializing report step 63/82 at 2019-11-16 (676 DAYS) line 1482
+Processing keyword WCONHIST at line 1486
+Complete report step 63 (13 DAYS) at 2019-11-29 (684 DAYS)
+
+Initializing report step 64/82 at 2019-11-29 (684 DAYS) line 1494
+Processing keyword WCONHIST at line 1498
+Complete report step 64 (2 DAYS) at 2019-12-01 (697 DAYS)
+
+Initializing report step 65/82 at 2019-12-01 (697 DAYS) line 1506
+Processing keyword WCONHIST at line 1510
+Complete report step 65 (31 DAYS) at 2020-01-01 (699 DAYS)
+
+Initializing report step 66/82 at 2020-01-01 (699 DAYS) line 1518
+Processing keyword WCONHIST at line 1522
+Complete report step 66 (10 DAYS) at 2020-01-11 (730 DAYS)
+
+Initializing report step 67/82 at 2020-01-11 (730 DAYS) line 1530
+Processing keyword WCONHIST at line 1534
+Complete report step 67 (20 DAYS) at 2020-01-31 (740 DAYS)
+
+Initializing report step 68/82 at 2020-01-31 (740 DAYS) line 1542
+Processing keyword WCONHIST at line 1546
+Complete report step 68 (1 DAYS) at 2020-02-01 (760 DAYS)
+
+Initializing report step 69/82 at 2020-02-01 (760 DAYS) line 1554
+Processing keyword WCONHIST at line 1558
+Complete report step 69 (7 DAYS) at 2020-02-08 (761 DAYS)
+
+Initializing report step 70/82 at 2020-02-08 (761 DAYS) line 1566
+Processing keyword WCONHIST at line 1570
+Complete report step 70 (13 DAYS) at 2020-02-21 (768 DAYS)
+
+Initializing report step 71/82 at 2020-02-21 (768 DAYS) line 1578
+Processing keyword WCONHIST at line 1582
+Complete report step 71 (9 DAYS) at 2020-03-01 (781 DAYS)
+
+Initializing report step 72/82 at 2020-03-01 (781 DAYS) line 1590
+Processing keyword WCONHIST at line 1594
+Complete report step 72 (31 DAYS) at 2020-04-01 (790 DAYS)
+
+Initializing report step 73/82 at 2020-04-01 (790 DAYS) line 1602
+Processing keyword WCONHIST at line 1606
+Complete report step 73 (3 DAYS) at 2020-04-04 (821 DAYS)
+
+Initializing report step 74/82 at 2020-04-04 (821 DAYS) line 1614
+Processing keyword WCONHIST at line 1618
+Complete report step 74 (20 DAYS) at 2020-04-24 (824 DAYS)
+
+Initializing report step 75/82 at 2020-04-24 (824 DAYS) line 1626
+Processing keyword WCONHIST at line 1630
+Complete report step 75 (7 DAYS) at 2020-05-01 (844 DAYS)
+
+Initializing report step 76/82 at 2020-05-01 (844 DAYS) line 1638
+Processing keyword WCONHIST at line 1642
+Processing keyword WCONINJH at line 1650
+Complete report step 76 (1 DAYS) at 2020-05-02 (851 DAYS)
+
+Initializing report step 77/82 at 2020-05-02 (851 DAYS) line 1656
+Complete report step 77 (3 DAYS) at 2020-05-05 (852 DAYS)
+
+Initializing report step 78/82 at 2020-05-05 (852 DAYS) line 1660
+Processing keyword WCONHIST at line 1664
+Processing keyword WCONINJH at line 1672
+Complete report step 78 (10 DAYS) at 2020-05-15 (855 DAYS)
+
+Initializing report step 79/82 at 2020-05-15 (855 DAYS) line 1678
+Processing keyword WCONHIST at line 1682
+Complete report step 79 (17 DAYS) at 2020-06-01 (865 DAYS)
+
+Initializing report step 80/82 at 2020-06-01 (865 DAYS) line 1690
+Processing keyword WCONHIST at line 1694
+Complete report step 80 (26 DAYS) at 2020-06-27 (882 DAYS)
+
+Initializing report step 81/82 at 2020-06-27 (882 DAYS) line 1702
+Processing keyword WCONHIST at line 1706
+Complete report step 81 (3 DAYS) at 2020-06-30 (908 DAYS)
+
+Initializing report step 82/82 at 2020-06-30 (908 DAYS) line 1714
+Processing keyword WCONHIST at line 1718
+Processing keyword RPTSCHED at line 1726
+Processing keyword RPTRST at line 1729
+Complete report step 82 (1 DAYS) at 2020-07-01 (911 DAYS)
+
+
+Warning: The network node keyword GPR is not supported in runs without networks
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 176
+
+Warning: Problem with keyword WOPRL
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 322
+Completion number 2 not defined for well A2
+
+Warning: Problem with keyword WOPRL
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 322
+Completion number 2 not defined for well A4
+
+Warning: Problem with keyword WOPRL
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 322
+Completion number 3 not defined for well A2
+
+Warning: Problem with keyword WWPRL
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 336
+Completion number 2 not defined for well A2
+
+Warning: Problem with keyword WWPRL
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 336
+Completion number 2 not defined for well A4
+
+Warning: Problem with keyword WWPRL
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 336
+Completion number 3 not defined for well A2
+
+Warning: Problem with keyword WGPRL
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 350
+Completion number 2 not defined for well A2
+
+Warning: Problem with keyword WGPRL
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 350
+Completion number 2 not defined for well A4
+
+Warning: Problem with keyword WGPRL
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 350
+Completion number 3 not defined for well A2
+
+Warning: Environment variable OMP_NUM_THREADS takes precedence over the --threads-per-process cmdline argument.
+
+Warning: Environment variable OMP_NUM_THREADS takes precedence over the --threads-per-process cmdline argument.
+
+Processing grid
+Total number of active cells: 71098 / total pore volume: 543870734 RM3
+
+Property tree for linear solvers:
+{
+    "maxiter": "20",
+    "tol": "0.0050000000000000001",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "cprw",
+        "use_well_weights": "false",
+        "add_wells": "true",
+        "weight_type": "trueimpes",
+        "pre_smooth": "0",
+        "post_smooth": "1",
+        "finesmoother": {
+            "type": "ParOverILU0",
+            "relaxation": "1"
+        },
+        "verbosity": "0",
+        "coarsesolver": {
+            "maxiter": "1",
+            "tol": "0.10000000000000001",
+            "solver": "loopsolver",
+            "verbosity": "0",
+            "preconditioner": {
+                "type": "amg",
+                "alpha": "0.33333333333300003",
+                "relaxation": "1",
+                "iterations": "1",
+                "coarsenTarget": "1200",
+                "pre_smooth": "1",
+                "post_smooth": "1",
+                "beta": "0",
+                "smoother": "ILU0",
+                "verbosity": "0",
+                "maxlevel": "15",
+                "skip_isolated": "0",
+                "accumulate": "1",
+                "prolongationdamping": "1",
+                "maxdistance": "2",
+                "maxconnectivity": "15",
+                "maxaggsize": "6",
+                "minaggsize": "4"
+            }
+        }
+    }
+}
+
+
+Warning: Unhandled summary keyword FGSR
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 18
+
+Warning: Unhandled summary keyword FWGR
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 73
+
+Warning: Unhandled summary keyword ROE
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 81
+
+Warning: Unhandled summary keyword GWGR
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 138
+
+Warning: Unhandled summary keyword WOGLR
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/summary/drogon.summary line 272
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (34,9,1) -> (34,10,23)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (21,12,1) -> (21,13,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (30,20,1) -> (31,20,9)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (30,20,1) -> (31,20,10)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,1) -> (18,22,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,24,1) -> (18,24,2)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,24,1) -> (18,24,3)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,24,1) -> (18,24,4)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,24,1) -> (18,24,5)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,24,1) -> (28,24,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,25,1) -> (28,25,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (20,25,15)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (20,25,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (19,26,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (20,25,17)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (19,26,17)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (20,25,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (19,26,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (20,25,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (19,26,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (20,25,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (19,26,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (20,25,21)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (20,25,27)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (19,26,27)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (20,25,28)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,1) -> (19,26,28)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,27,1) -> (19,27,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,27,1) -> (19,27,17)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,1) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (18,29,1) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (36,67,1) -> (37,67,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (34,9,2) -> (34,10,23)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (21,12,2) -> (21,13,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (30,20,2) -> (31,20,9)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (30,20,2) -> (31,20,10)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,2) -> (18,22,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,24,2) -> (28,24,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,25,2) -> (28,25,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,25,2) -> (34,25,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (20,25,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (20,25,17)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (19,26,17)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (20,25,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (19,26,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (20,25,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (19,26,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (20,25,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (19,26,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (20,25,21)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (20,25,27)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (19,26,27)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (20,25,28)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (19,26,28)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (20,25,29)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,26,2) -> (19,26,29)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,2) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (18,29,2) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (36,67,2) -> (37,67,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (34,9,3) -> (34,10,23)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (21,12,3) -> (21,13,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (30,20,3) -> (31,20,9)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (30,20,3) -> (31,20,10)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,3) -> (18,22,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,3) -> (18,23,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,23,3) -> (34,23,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,24,3) -> (28,24,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,25,3) -> (34,25,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,26,3) -> (34,26,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,3) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (18,29,3) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (26,38,3) -> (27,38,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (36,67,3) -> (37,67,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (34,9,4) -> (33,9,23)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (34,9,4) -> (34,10,23)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (30,20,4) -> (31,20,10)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,4) -> (18,22,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,4) -> (18,22,21)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,4) -> (18,23,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,23,4) -> (34,23,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,24,4) -> (28,24,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,25,4) -> (34,25,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,26,4) -> (34,26,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,4) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (18,29,4) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (26,38,4) -> (27,38,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (36,67,4) -> (37,67,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (34,9,5) -> (33,9,23)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,5) -> (18,22,21)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,22,5) -> (34,22,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,5) -> (18,23,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,23,5) -> (34,23,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,5) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (18,29,5) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (36,67,5) -> (37,67,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (34,9,6) -> (33,9,23)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (29,21,6) -> (29,22,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,6) -> (18,22,21)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,22,6) -> (34,22,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,6) -> (18,23,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,6) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (18,29,6) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (36,68,6) -> (37,68,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (34,9,7) -> (33,9,23)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (29,21,7) -> (30,21,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (29,21,7) -> (29,22,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,7) -> (18,22,21)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,22,7) -> (34,22,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,7) -> (18,23,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,7) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (18,29,7) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (26,49,7) -> (27,49,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,50,7) -> (27,49,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (36,68,7) -> (37,68,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (29,21,8) -> (30,21,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,8) -> (18,22,21)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,8) -> (18,23,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,25,8) -> (34,25,29)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,25,8) -> (34,25,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,25,8) -> (34,25,31)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,26,8) -> (34,26,29)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,26,8) -> (34,26,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,26,8) -> (34,26,31)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,27,8) -> (34,27,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,27,8) -> (34,27,31)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,8) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (18,29,8) -> (18,28,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (26,49,8) -> (27,49,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,50,8) -> (27,49,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (36,68,8) -> (37,68,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (33,6,9) -> (33,5,10)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,9) -> (18,22,21)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,9) -> (18,23,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,24,9) -> (18,24,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,26,9) -> (34,26,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,26,9) -> (34,26,31)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,27,9) -> (34,27,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (35,27,9) -> (34,27,31)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (26,49,9) -> (27,49,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (36,68,9) -> (37,68,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,10) -> (18,22,21)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,10) -> (18,23,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,24,10) -> (18,24,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,10) -> (18,28,28)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,10) -> (18,28,29)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,10) -> (18,28,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,10) -> (19,27,31)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (19,28,10) -> (18,28,31)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (26,49,10) -> (27,49,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (36,68,10) -> (37,68,11)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,13,11) -> (21,13,22)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,13,11) -> (21,13,27)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,13,11) -> (21,13,28)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,13,11) -> (21,13,29)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,13,11) -> (21,13,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (20,13,11) -> (21,13,31)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,11) -> (18,22,21)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,24,11) -> (18,24,12)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (26,49,11) -> (27,49,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (42,49,11) -> (41,49,27)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,12) -> (18,22,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,12) -> (18,22,27)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,12) -> (18,22,28)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,12) -> (18,22,29)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,12) -> (18,22,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,22,12) -> (18,22,31)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,12) -> (18,23,14)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,12) -> (18,23,15)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,12) -> (18,23,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,12) -> (18,23,17)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,12) -> (18,23,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,12) -> (18,23,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,12) -> (18,23,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,23,12) -> (18,23,27)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,24,12) -> (18,24,13)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,24,12) -> (18,24,14)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (17,24,12) -> (18,24,15)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (26,49,12) -> (27,49,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,13,14) -> (26,13,15)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (16,31,14) -> (15,31,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,13,15) -> (26,13,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,14,15) -> (26,14,16)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,14,15) -> (26,14,17)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,14,15) -> (26,14,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,14,15) -> (26,14,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,14,15) -> (26,14,27)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,15,15) -> (26,15,18)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,15,15) -> (26,15,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,15,15) -> (26,15,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,15,15) -> (26,15,21)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,15,15) -> (26,15,27)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,15,15) -> (26,15,28)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,15,15) -> (26,15,29)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,15,15) -> (26,15,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (27,15,15) -> (26,15,31)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (16,31,15) -> (15,31,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (16,31,16) -> (15,31,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (25,48,16) -> (25,47,28)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (25,48,16) -> (26,48,28)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (25,48,16) -> (25,47,29)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (25,48,16) -> (26,48,29)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (25,48,16) -> (25,47,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (25,48,16) -> (26,48,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (16,31,17) -> (15,31,19)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (23,46,17) -> (23,45,28)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (23,46,17) -> (24,46,28)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (23,46,17) -> (23,45,29)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (23,46,17) -> (24,46,29)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (23,46,17) -> (23,45,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (23,46,17) -> (24,46,30)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (23,11,19) -> (23,10,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (23,11,19) -> (22,11,20)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (23,11,19) -> (23,10,27)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (23,11,19) -> (22,11,27)
+
+Warning: Problem with EDITNNC keyword
+In /scratch/fmu/lilbe/drogon_testdata_99_warn_flow/eclipse/include/edit/drogon.trans line 440 
+No NNC defined for connection (23,11,19) -> (23,10,28)
+
+Warning: Problems with EDITNNC keyword
+A total of 215 connections not defined in grid
+
+Warning: Saturation Function End-point Consistency Problems
+Consistency Problem:
+  Non-negative minimum oil saturation in G/O system
+  SWL + SGU <= 1
+  Total Violations: 21413
+
+Sample Violations
++--------------+---------------+---------------+---------------+
+| Grid Block   | SWL           | SGU           | SWL + SGU     |
++--------------+---------------+---------------+---------------+
+| ( 7, 73,  2) |  2.017410e-02 |  9.798259e-01 |  1.000000e+00 |
+| ( 5, 31, 11) |  2.395465e-02 |  9.760454e-01 |  1.000000e+00 |
+| (23, 38, 27) |  1.945122e-02 |  9.805488e-01 |  1.000000e+00 |
+| (31, 40, 28) |  1.681723e-02 |  9.831828e-01 |  1.000000e+00 |
+| (34,  3, 29) |  1.989110e-02 |  9.801089e-01 |  1.000000e+00 |
++--------------+---------------+---------------+---------------+
+
+
+
+LIST OF ALL NON-ZERO THRESHOLD PRESSURES
+----------------------------------------
+
+    FLOW FROM REGION             TO REGION                     THRESHOLD PRESSURE
+    ----------------             ---------                     ------------------
+         1                            2                           0.572402       BARSA
+         1                            3                        8.945167e-10       BARSA
+         1                            4                           1.144806       BARSA
+         1                            5                                  0       BARSA
+         1                            6                                  0       BARSA
+         1                            7                                  0       BARSA
+         2                            3                        3.67748e-07       BARSA
+         2                            4                                  0       BARSA
+         2                            5                         0.00976378       BARSA
+         2                            6                        4.087165e-09       BARSA
+         2                            7                                  0       BARSA
+         3                            4                            0.58667       BARSA
+         3                            5                        4.811957e-10       BARSA
+         3                            6                        0.003514202       BARSA
+         3                            7                        1.079261e-08       BARSA
+         4                            5                                  0       BARSA
+         4                            6                                  0       BARSA
+         4                            7                                  0       BARSA
+         5                            6                        0.003208209       BARSA
+         5                            7                                  0       BARSA
+         6                            7                          0.5262228       BARSA
+    ----------------             ---------                     ------------------
+
+
+
+================ Starting main simulation loop ===============
+
+
+Report step  0/82 at day 0/912, date = 01-Jan-2018
+
+Warning: Keyword 'FIPRESV' is unhandled for output to restart file.
+Using Newton nonlinear solver.
+
+Starting time step 0, stepsize 1 days, at day 0/4, date = 01-Jan-2018
+Restart file written for report step  0/82, date = 01-Jan-2018 00:00:00
+ Newton its= 2, linearizations= 3 (0.3sec), linear its=  1 (0.3sec)
+
+Starting time step 1, stepsize 3 days, at day 1/4, date = 02-Jan-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step  1/82 at day 4/912, date = 05-Jan-2018
+
+Starting time step 0, stepsize 9 days, at day 4/31, date = 05-Jan-2018
+ Newton its= 5, linearizations= 6 (0.3sec), linear its=  5 (0.5sec)
+
+Starting time step 1, stepsize 4.1157 days, at day 13/31, date = 14-Jan-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+Starting time step 2, stepsize 6.94215 days, at day 17.1157/31, date = 18-Jan-2018
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  6 (0.4sec)
+
+Starting time step 3, stepsize 6.94215 days, at day 24.0578/31, date = 25-Jan-2018
+ Newton its= 3, linearizations= 4 (0.2sec), linear its= 10 (0.5sec)
+
+
+Report step  2/82 at day 31/912, date = 01-Feb-2018
+
+Starting time step 0, stepsize 14 days, at day 31/59, date = 01-Feb-2018
+ Newton its= 4, linearizations= 5 (0.3sec), linear its=  9 (0.6sec)
+
+Starting time step 1, stepsize 14 days, at day 45/59, date = 15-Feb-2018
+ Newton its= 4, linearizations= 5 (0.2sec), linear its= 10 (0.6sec)
+
+
+Report step  3/82 at day 59/912, date = 01-Mar-2018
+
+Starting time step 0, stepsize 9 days, at day 59/68, date = 01-Mar-2018
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  9 (0.5sec)
+
+
+Report step  4/82 at day 68/912, date = 10-Mar-2018
+
+Starting time step 0, stepsize 20 days, at day 68/88, date = 10-Mar-2018
+ Newton its= 6, linearizations= 7 (0.4sec), linear its=  6 (0.7sec)
+
+
+Report step  5/82 at day 88/912, date = 30-Mar-2018
+
+Starting time step 0, stepsize 2 days, at day 88/90, date = 30-Mar-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step  6/82 at day 90/912, date = 01-Apr-2018
+
+Starting time step 0, stepsize 6 days, at day 90/117, date = 01-Apr-2018
+ Newton its= 5, linearizations= 6 (0.3sec), linear its=  9 (0.7sec)
+
+Starting time step 1, stepsize 13.2 days, at day 96/117, date = 07-Apr-2018
+ Newton its= 5, linearizations= 6 (0.3sec), linear its=  8 (0.6sec)
+
+Starting time step 2, stepsize 7.8 days, at day 109.2/117, date = 20-Apr-2018
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  4 (0.3sec)
+
+
+Report step  7/82 at day 117/912, date = 28-Apr-2018
+
+Starting time step 0, stepsize 3 days, at day 117/120, date = 28-Apr-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step  8/82 at day 120/912, date = 01-May-2018
+
+Starting time step 0, stepsize 7 days, at day 120/127, date = 01-May-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step  9/82 at day 127/912, date = 08-May-2018
+
+Starting time step 0, stepsize 12 days, at day 127/151, date = 08-May-2018
+ Newton its= 7, linearizations= 8 (0.4sec), linear its=  9 (0.8sec)
+
+Starting time step 1, stepsize 12 days, at day 139/151, date = 20-May-2018
+ Newton its= 5, linearizations= 6 (0.3sec), linear its=  8 (0.7sec)
+
+
+Report step 10/82 at day 151/912, date = 01-Jun-2018
+
+Starting time step 0, stepsize 1 days, at day 151/152, date = 01-Jun-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step 11/82 at day 152/912, date = 02-Jun-2018
+
+Starting time step 0, stepsize 3 days, at day 152/158, date = 02-Jun-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+Starting time step 1, stepsize 3 days, at day 155/158, date = 05-Jun-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step 12/82 at day 158/912, date = 08-Jun-2018
+
+Starting time step 0, stepsize 1 days, at day 158/159, date = 08-Jun-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step 13/82 at day 159/912, date = 09-Jun-2018
+
+Starting time step 0, stepsize 3 days, at day 159/172, date = 09-Jun-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+Starting time step 1, stepsize 5 days, at day 162/172, date = 12-Jun-2018
+ Newton its= 4, linearizations= 5 (0.3sec), linear its=  5 (0.4sec)
+
+Starting time step 2, stepsize 5 days, at day 167/172, date = 17-Jun-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step 14/82 at day 172/912, date = 22-Jun-2018
+
+Starting time step 0, stepsize 8 days, at day 172/180, date = 22-Jun-2018
+ Newton its= 4, linearizations= 5 (0.3sec), linear its=  4 (0.4sec)
+
+
+Report step 15/82 at day 180/912, date = 30-Jun-2018
+
+Starting time step 0, stepsize 1 days, at day 180/181, date = 30-Jun-2018
+
+Warning: Keyword 'FIPRESV' is unhandled for output to restart file.
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  1 (0.2sec)
+
+                              **************************************************************************
+  BALANCE  AT       181  DAYS *Drogon synthetic reservoir model                                          *
+  REPORT   16    01 Jul 2018  *                                             Flow  version 2025.10-pre  *
+                              **************************************************************************
+
+
+                                                     ==================================================
+                                                     :                  FIELD TOTALS                  :
+                                                     :        PAV  =           280  BARSA             :
+                                                     :        PORV =     543870734  RM3               :
+                                                     : Pressure is weighted by hydrocarbon pore volume:
+                                                     : Pore volumes are taken at reference conditions :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :   44365413        172578       44537991   :   458909521    :  1230442518     6292581630    7523024148  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :   45456650        184918       45641568   :   458478364    :  1201555717     6473854099    7675409816  :
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  1           :
+                                                     :        PAV  =           287  BARSA             :
+                                                     :        PORV =      92144333  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    1966928         1535        1968463    :    86354456    :    7177750      279733318     286911068   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    1971585          0          1971585    :    86497372    :       0         277638546     277638546   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  2           :
+                                                     :        PAV  =           283  BARSA             :
+                                                     :        PORV =      23847184  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    7293474          0          7293474    :    12900975    :       9         1027066192    1027066201  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    7412666          0          7412666    :    12811296    :       0         1043851673    1043851673  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  3           :
+                                                     :        PAV  =           277  BARSA             :
+                                                     :        PORV =      16265885  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    2270268         497         2270765    :    12556866    :    2974513      319145573     322120086   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    2462605          0          2462605    :    12337180    :       0         346784057     346784057   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  4           :
+                                                     :        PAV  =           291  BARSA             :
+                                                     :        PORV =       7720051  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    241594         97576         339170    :    4124340     :   699464156      45776237     745240393   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    232168         109290        341458    :    4147647     :   711438194      45488731     756926926   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  5           :
+                                                     :        PAV  =           281  BARSA             :
+                                                     :        PORV =       2279667  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    1047563          0          1047563    :     743755     :       0         147517792     147517792   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    1054576          0          1054576    :     743741     :       0         148505401     148505401   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  6           :
+                                                     :        PAV  =           262  BARSA             :
+                                                     :        PORV =      16715360  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    7095680         3730        7099410    :    6165430     :   23025803      977645806     1000671610  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    7339772          0          7339772    :    5998550     :       0         1033586644    1033586644  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  7           :
+                                                     :        PAV  =           289  BARSA             :
+                                                     :        PORV =      31732729  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :     1800            0            1800     :    30715372    :       0           253463        253463    :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       0             0             0       :    30749971    :       0             0             0       :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  8           :
+                                                     :        PAV  =           288  BARSA             :
+                                                     :        PORV =      99297143  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    448304          348          448652    :    95424007    :    1683583       63727676      65411258   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    442638           0           442638    :    95552708    :       0          62332262      62332262   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  9           :
+                                                     :        PAV  =           288  BARSA             :
+                                                     :        PORV =       8461267  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    3434988          0          3434988    :    3405080     :       0         483715522     483715522   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    3468315          0          3468315    :    3383744     :       0         488408096     488408096   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 10           :
+                                                     :        PAV  =           289  BARSA             :
+                                                     :        PORV =      14236567  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    1112945          0          1112945    :    12228937    :       0         156723562     156723562   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    1118839          0          1118839    :    12237246    :       0         157554944     157554944   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 11           :
+                                                     :        PAV  =           291  BARSA             :
+                                                     :        PORV =       7261494  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    387350         60577         447927    :    4566883     :   436631131      73081867     509712998   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    382426         67683         450109    :    4603488     :   438728927      74928792     513657719   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 12           :
+                                                     :        PAV  =           299  BARSA             :
+                                                     :        PORV =       1639655  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    886473           0           886473    :     357496     :       0         124833169     124833169   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    886796           0           886796    :     357529     :       0         124878569     124878569   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 13           :
+                                                     :        PAV  =           266  BARSA             :
+                                                     :        PORV =      12433656  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    4843348          20         4843368    :    5241915     :    115067       682064670     682179736   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    5043745          0          5043745    :    5041362     :       0         710260157     710260157   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 14           :
+                                                     :        PAV  =           292  BARSA             :
+                                                     :        PORV =      25328539  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      37             0             37      :    24532547    :       0            5154          5154     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       0             0             0       :    24555567    :       0             0             0       :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 15           :
+                                                     :        PAV  =           289  BARSA             :
+                                                     :        PORV =      89597072  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :     36220           0           36220     :    86646439    :      29          5100650       5100679    :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :     36869           0           36869     :    86742407    :       0          5191921       5191921    :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 16           :
+                                                     :        PAV  =           290  BARSA             :
+                                                     :        PORV =      36879049  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    4243614          0          4243614    :    29774257    :       0         597581406     597581407   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    4271633          0          4271633    :    29794439    :       0         601531305     601531305   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 17           :
+                                                     :        PAV  =           290  BARSA             :
+                                                     :        PORV =       5687619  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    356630           0           356630    :    5007970     :       0          50221267      50221267   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    358721           0           358721    :    5011669     :       0          50515111      50515111   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 18           :
+                                                     :        PAV  =           291  BARSA             :
+                                                     :        PORV =       3145457  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    702118          8295         710413    :    1698566     :   59370478      132380980     191751458   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    703652          7945         711597    :    1723811     :   51388595      137866556     189255152   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 19           :
+                                                     :        PAV  =           283  BARSA             :
+                                                     :        PORV =       2355763  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    1172319          0          1172319    :     644834     :       0         165085441     165085441   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    1201634          0          1201634    :     614786     :       0         169214078     169214078   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 20           :
+                                                     :        PAV  =           283  BARSA             :
+                                                     :        PORV =      18527269  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    6823760          0          6823760    :    8411614     :       0         960921883     960921883   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    7068011          0          7068011    :    8136152     :       0         995317254     995317254   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 21           :
+                                                     :        PAV  =           301  BARSA             :
+                                                     :        PORV =      28314973  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       0             0             0       :    27407782    :       0             0             0       :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       0             0             0       :    27437699    :       0             0             0       :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ===================================
+                                                     :  RESERVOIR VOLUMES      RM3     :
+ :---------:---------------:---------------:---------------:---------------:---------------:
+ : REGION  :  TOTAL PORE   :  PORE VOLUME  :  PORE VOLUME  :  PORE VOLUME  :  PORE VOLUME  :
+ :         :    VOLUME     :  CONTAINING   :  CONTAINING   :  CONTAINING   :  CONTAINING   :
+ :         :               :      OIL      :     WATER     :      GAS      : HYDRO-CARBON  :
+ :---------:---------------:---------------:---------------:---------------:---------------:
+ :FIELD    :      544320399:       64146383:      474754787:        5419229:       69565612:
+ :1        :       92216984:        2838893:       89345651:          32440:        2871333:
+ :2        :       23856656:       10506452:       13350205:              0:       10506452:
+ :3        :       16278712:        3274411:       12989558:          14744:        3289154:
+ :4        :        7725993:         389440:        4267000:        3069553:        3458992:
+ :5        :        2279884:        1509990:         769893:              0:        1509990:
+ :6        :       16709912:       10215306:        6379113:         115493:       10330799:
+ :7        :       31771774:           2589:       31769185:              0:           2589:
+ :8        :       99380565:         646745:       98726220:           7600:         654345:
+ :9        :        8465454:        4941729:        3523725:              0:        4941729:
+ :10       :       14250808:        1600726:       12650081:              0:        1600726:
+ :11       :        7266956:         623574:        4725001:        1918382:        2541956:
+ :12       :        1641447:        1271633:         369814:              0:        1271633:
+ :13       :       12432342:        7008049:        5423731:            562:        7008611:
+ :14       :       25368023:             53:       25367971:              0:             53:
+ :15       :       89686532:          52091:       89634441:              0:          52091:
+ :16       :       36907667:        6102559:       30805108:              0:        6102559:
+ :17       :        5693347:         512876:        5180471:              0:         512876:
+ :18       :        3147828:        1130033:        1757337:         260457:        1390490:
+ :19       :        2356253:        1688840:         667413:              0:        1688840:
+ :20       :       18534463:        9830393:        8704070:              0:        9830393:
+ :21       :       28348799:              0:       28348799:              0:              0:
+ ===========================================================================================
+
+                              **************************************************************************
+  BALZON   AT       181  DAYS *Drogon synthetic reservoir model                                          *
+  REPORT   16    01 Jul 2018  *                                             Flow  version 2025.10-pre  *
+                              **************************************************************************
+
+
+                                                     ==================================================
+                                                     :              FIPZON REPORT REGION  1           :
+                                                     :        PAV  =           277  BARSA             :
+                                                     :        PORV =     190705210  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :   19917307        103338       20020645   :   153561194    :   732642231     2797138382    3529780613  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :   20473372        109290       20582662   :   153285758    :   711438194     2895855053    3607293247  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPZON REPORT REGION  2           :
+                                                     :        PAV  =           281  BARSA             :
+                                                     :        PORV =     168658322  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :   11113445        60945        11174390   :   145756865    :   438429780     1584151620    2022581400  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :   11342759        67683        11410442   :   145731642    :   438728927     1618362820    2057091747  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPZON REPORT REGION  3           :
+                                                     :        PAV  =           286  BARSA             :
+                                                     :        PORV =     184507202  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :   13334661         8295        13342956   :   159591461    :   59370506      1911291628    1970662134  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :   13640520         7945        13648464   :   159460964    :   51388595      1959636226    2011024821  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ===================================
+                                                     :  RESERVOIR VOLUMES      RM3     :
+ :---------:---------------:---------------:---------------:---------------:---------------:
+ : REGION  :  TOTAL PORE   :  PORE VOLUME  :  PORE VOLUME  :  PORE VOLUME  :  PORE VOLUME  :
+ :         :    VOLUME     :  CONTAINING   :  CONTAINING   :  CONTAINING   :  CONTAINING   :
+ :         :               :      OIL      :     WATER     :      GAS      : HYDRO-CARBON  :
+ :---------:---------------:---------------:---------------:---------------:---------------:
+ :FIELD    :      544320399:       64146383:      474754787:        5419229:       69565612:
+ :1        :      190839915:       28737080:      158870605:        3232229:       31969310:
+ :2        :      168805595:       16092510:      150786542:        1926543:       18019053:
+ :3        :      184674889:       19316792:      165097640:         260457:       19577250:
+ :4        :              0:              0:              0:              0:              0:
+ :5        :              0:              0:              0:              0:              0:
+ :6        :              0:              0:              0:              0:              0:
+ :7        :              0:              0:              0:              0:              0:
+ :8        :              0:              0:              0:              0:              0:
+ :9        :              0:              0:              0:              0:              0:
+ :10       :              0:              0:              0:              0:              0:
+ :11       :              0:              0:              0:              0:              0:
+ :12       :              0:              0:              0:              0:              0:
+ :13       :              0:              0:              0:              0:              0:
+ :14       :              0:              0:              0:              0:              0:
+ :15       :              0:              0:              0:              0:              0:
+ :16       :              0:              0:              0:              0:              0:
+ :17       :              0:              0:              0:              0:              0:
+ :18       :              0:              0:              0:              0:              0:
+ :19       :              0:              0:              0:              0:              0:
+ :20       :              0:              0:              0:              0:              0:
+ :21       :              0:              0:              0:              0:              0:
+ ===========================================================================================
+
+
+Report step 16/82 at day 181/912, date = 01-Jul-2018
+
+Starting time step 0, stepsize 2 days, at day 181/183, date = 01-Jul-2018
+Restart file written for report step 16/82, date = 01-Jul-2018 00:00:00
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step 17/82 at day 183/912, date = 03-Jul-2018
+
+Starting time step 0, stepsize 6 days, at day 183/193, date = 03-Jul-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.3sec)
+
+Starting time step 1, stepsize 4 days, at day 189/193, date = 09-Jul-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  4 (0.3sec)
+
+
+Report step 18/82 at day 193/912, date = 13-Jul-2018
+
+Starting time step 0, stepsize 12 days, at day 193/212, date = 13-Jul-2018
+ Newton its= 5, linearizations= 6 (0.3sec), linear its=  6 (0.5sec)
+
+Starting time step 1, stepsize 7 days, at day 205/212, date = 25-Jul-2018
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  4 (0.3sec)
+
+
+Report step 19/82 at day 212/912, date = 01-Aug-2018
+
+Starting time step 0, stepsize 12 days, at day 212/236, date = 01-Aug-2018
+ Newton its= 4, linearizations= 5 (0.3sec), linear its=  5 (0.5sec)
+
+Starting time step 1, stepsize 12 days, at day 224/236, date = 13-Aug-2018
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  4 (0.4sec)
+
+
+Report step 20/82 at day 236/912, date = 25-Aug-2018
+
+Starting time step 0, stepsize 7 days, at day 236/243, date = 25-Aug-2018
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  5 (0.4sec)
+
+
+Report step 21/82 at day 243/912, date = 01-Sep-2018
+
+Starting time step 0, stepsize 11 days, at day 243/254, date = 01-Sep-2018
+ Newton its= 4, linearizations= 5 (0.3sec), linear its=  6 (0.5sec)
+
+
+Report step 22/82 at day 254/912, date = 12-Sep-2018
+
+Starting time step 0, stepsize 2 days, at day 254/256, date = 12-Sep-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step 23/82 at day 256/912, date = 14-Sep-2018
+
+Starting time step 0, stepsize 4 days, at day 256/264, date = 14-Sep-2018
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  2 (0.3sec)
+
+Starting time step 1, stepsize 4 days, at day 260/264, date = 18-Sep-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.3sec)
+
+
+Report step 24/82 at day 264/912, date = 22-Sep-2018
+
+Starting time step 0, stepsize 9 days, at day 264/273, date = 22-Sep-2018
+    Oscillating behavior detected: Relaxation set to 0.900000
+ Newton its= 4, linearizations= 5 (0.3sec), linear its=  9 (0.6sec)
+
+
+Report step 25/82 at day 273/912, date = 01-Oct-2018
+
+Starting time step 0, stepsize 4 days, at day 273/277, date = 01-Oct-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  7 (0.4sec)
+
+
+Report step 26/82 at day 277/912, date = 05-Oct-2018
+
+Starting time step 0, stepsize 12 days, at day 277/304, date = 05-Oct-2018
+ Newton its= 4, linearizations= 5 (0.3sec), linear its= 13 (0.8sec)
+
+Starting time step 1, stepsize 15 days, at day 289/304, date = 17-Oct-2018
+ Newton its= 5, linearizations= 6 (0.3sec), linear its= 12 (0.8sec)
+
+
+Report step 27/82 at day 304/912, date = 01-Nov-2018
+
+Starting time step 0, stepsize 6 days, at day 304/310, date = 01-Nov-2018
+ Newton its= 4, linearizations= 5 (0.3sec), linear its=  9 (0.6sec)
+
+
+Report step 28/82 at day 310/912, date = 07-Nov-2018
+
+Starting time step 0, stepsize 10 days, at day 310/320, date = 07-Nov-2018
+ Newton its= 4, linearizations= 5 (0.3sec), linear its= 12 (0.7sec)
+
+
+Report step 29/82 at day 320/912, date = 17-Nov-2018
+
+Starting time step 0, stepsize 14 days, at day 320/334, date = 17-Nov-2018
+ Newton its= 9, linearizations=10 (0.5sec), linear its=  7 (1.0sec)
+
+
+Report step 30/82 at day 334/912, date = 01-Dec-2018
+
+Starting time step 0, stepsize 6 days, at day 334/340, date = 01-Dec-2018
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  3 (0.3sec)
+
+
+Report step 31/82 at day 340/912, date = 07-Dec-2018
+
+Starting time step 0, stepsize 8 days, at day 340/348, date = 07-Dec-2018
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  4 (0.3sec)
+
+
+Report step 32/82 at day 348/912, date = 15-Dec-2018
+
+Starting time step 0, stepsize 2 days, at day 348/350, date = 15-Dec-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step 33/82 at day 350/912, date = 17-Dec-2018
+
+Starting time step 0, stepsize 1 days, at day 350/351, date = 17-Dec-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step 34/82 at day 351/912, date = 18-Dec-2018
+
+Starting time step 0, stepsize 3 days, at day 351/361, date = 18-Dec-2018
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+Starting time step 1, stepsize 7 days, at day 354/361, date = 21-Dec-2018
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  3 (0.3sec)
+
+
+Report step 35/82 at day 361/912, date = 28-Dec-2018
+
+Starting time step 0, stepsize 4 days, at day 361/365, date = 28-Dec-2018
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  3 (0.3sec)
+
+
+Report step 36/82 at day 365/912, date = 01-Jan-2019
+
+Starting time step 0, stepsize 12 days, at day 365/396, date = 01-Jan-2019
+ Newton its= 5, linearizations= 6 (0.3sec), linear its=  3 (0.5sec)
+
+Starting time step 1, stepsize 19 days, at day 377/396, date = 13-Jan-2019
+ Newton its= 6, linearizations= 7 (0.4sec), linear its=  4 (0.6sec)
+
+
+Report step 37/82 at day 396/912, date = 01-Feb-2019
+
+Starting time step 0, stepsize 8 days, at day 396/404, date = 01-Feb-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step 38/82 at day 404/912, date = 09-Feb-2019
+
+Starting time step 0, stepsize 20 days, at day 404/424, date = 09-Feb-2019
+ Newton its= 6, linearizations= 7 (0.4sec), linear its=  6 (0.6sec)
+
+
+Report step 39/82 at day 424/912, date = 01-Mar-2019
+
+Starting time step 0, stepsize 8 days, at day 424/432, date = 01-Mar-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  3 (0.3sec)
+
+
+Report step 40/82 at day 432/912, date = 09-Mar-2019
+
+Starting time step 0, stepsize 13 days, at day 432/445, date = 09-Mar-2019
+ Newton its= 4, linearizations= 5 (0.3sec), linear its=  3 (0.4sec)
+
+
+Report step 41/82 at day 445/912, date = 22-Mar-2019
+
+Starting time step 0, stepsize 10 days, at day 445/455, date = 22-Mar-2019
+ Newton its= 4, linearizations= 5 (0.3sec), linear its=  6 (0.4sec)
+
+
+Report step 42/82 at day 455/912, date = 01-Apr-2019
+
+Starting time step 0, stepsize 15 days, at day 455/485, date = 01-Apr-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  5 (0.4sec)
+
+Starting time step 1, stepsize 15 days, at day 470/485, date = 16-Apr-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  4 (0.3sec)
+
+
+Report step 43/82 at day 485/912, date = 01-May-2019
+
+Starting time step 0, stepsize 3 days, at day 485/488, date = 01-May-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  4 (0.4sec)
+
+
+Report step 44/82 at day 488/912, date = 04-May-2019
+
+Starting time step 0, stepsize 1 days, at day 488/489, date = 04-May-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step 45/82 at day 489/912, date = 05-May-2019
+
+Starting time step 0, stepsize 3 days, at day 489/508, date = 05-May-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  3 (0.3sec)
+
+Starting time step 1, stepsize 9 days, at day 492/508, date = 08-May-2019
+    Oscillating behavior detected: Relaxation set to 0.900000
+ Newton its=11, linearizations=12 (0.6sec), linear its= 17 (1.2sec)
+
+Starting time step 2, stepsize 3.5 days, at day 501/508, date = 17-May-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+Starting time step 3, stepsize 3.5 days, at day 504.5/508, date = 20-May-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step 46/82 at day 508/912, date = 24-May-2019
+
+Starting time step 0, stepsize 8 days, at day 508/516, date = 24-May-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  4 (0.2sec)
+
+
+Report step 47/82 at day 516/912, date = 01-Jun-2019
+
+Starting time step 0, stepsize 13 days, at day 516/529, date = 01-Jun-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  5 (0.3sec)
+
+
+Report step 48/82 at day 529/912, date = 14-Jun-2019
+
+Starting time step 0, stepsize 16 days, at day 529/545, date = 14-Jun-2019
+ Newton its= 7, linearizations= 8 (0.4sec), linear its=  7 (0.8sec)
+
+
+Report step 49/82 at day 545/912, date = 30-Jun-2019
+
+Starting time step 0, stepsize 1 days, at day 545/546, date = 30-Jun-2019
+
+Warning: Keyword 'FIPRESV' is unhandled for output to restart file.
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  1 (0.2sec)
+
+                              **************************************************************************
+  BALANCE  AT       546  DAYS *Drogon synthetic reservoir model                                          *
+  REPORT   50    01 Jul 2019  *                                             Flow  version 2025.10-pre  *
+                              **************************************************************************
+
+
+                                                     ==================================================
+                                                     :                  FIELD TOTALS                  :
+                                                     :        PAV  =           261  BARSA             :
+                                                     :        PORV =     543870734  RM3               :
+                                                     : Pressure is weighted by hydrocarbon pore volume:
+                                                     : Pore volumes are taken at reference conditions :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :   40244217        183788       40428005   :   463217884    :  1394498620     5545084961    6939583581  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :   45456650        184918       45641568   :   458478364    :  1201555717     6473854099    7675409816  :
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  1           :
+                                                     :        PAV  =           278  BARSA             :
+                                                     :        PORV =      92144333  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    1926340         8711        1935051    :    86133967    :   43718612      274883237     318601849   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    1971585          0          1971585    :    86497372    :       0         277638546     277638546   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  2           :
+                                                     :        PAV  =           253  BARSA             :
+                                                     :        PORV =      23847184  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    6539487         5836        6545323    :    13729870    :   36302620      892135326     928437946   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    7412666          0          7412666    :    12811296    :       0         1043851673    1043851673  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  3           :
+                                                     :        PAV  =           267  BARSA             :
+                                                     :        PORV =      16265885  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    1907467         3075        1910542    :    12982497    :   19334571      262000664     281335234   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    2462605          0          2462605    :    12337180    :       0         346784057     346784057   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  4           :
+                                                     :        PAV  =           282  BARSA             :
+                                                     :        PORV =       7720051  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    249366         82166         331531    :    4232727     :   656166178      45494314     701660492   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    232168         109290        341458    :    4147647     :   711438194      45488731     756926926   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  5           :
+                                                     :        PAV  =           252  BARSA             :
+                                                     :        PORV =       2279667  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    1027965         924         1028889    :     742726     :    5679822      139645073     145324895   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    1054576          0          1054576    :     743741     :       0         148505401     148505401   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  6           :
+                                                     :        PAV  =           241  BARSA             :
+                                                     :        PORV =      16715360  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    6549511        12138        6561649    :    6706673     :   84714914      842632914     927347828   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    7339772          0          7339772    :    5998550     :       0         1033586644    1033586644  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  7           :
+                                                     :        PAV  =           265  BARSA             :
+                                                     :        PORV =      31732729  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :     1862            0            1862     :    30678706    :       0           262185        262185    :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       0             0             0       :    30749971    :       0             0             0       :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  8           :
+                                                     :        PAV  =           280  BARSA             :
+                                                     :        PORV =      99297143  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    459926          3252         463178    :    95246199    :   17688705       66013758      83702463   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    442638           0           442638    :    95552708    :       0          62332262      62332262   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  9           :
+                                                     :        PAV  =           276  BARSA             :
+                                                     :        PORV =       8461267  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    3151061          0          3151061    :    3779941     :       0         443733352     443733352   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    3468315          0          3468315    :    3383744     :       0         488408096     488408096   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 10           :
+                                                     :        PAV  =           281  BARSA             :
+                                                     :        PORV =      14236567  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    1009616          0          1009616    :    12358772    :       0         142172857     142172857   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    1118839          0          1118839    :    12237246    :       0         157554944     157554944   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 11           :
+                                                     :        PAV  =           282  BARSA             :
+                                                     :        PORV =       7261494  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    393939         51768         445707    :    4613016     :   414761294      71463733     486225027   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    382426         67683         450109    :    4603488     :   438728927      74928792     513657719   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 12           :
+                                                     :        PAV  =           204  BARSA             :
+                                                     :        PORV =       1639655  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    824909          2499         827408    :     357864     :   21855203       88799449     110654652   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    886796           0           886796    :     357529     :       0         124878569     124878569   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 13           :
+                                                     :        PAV  =           251  BARSA             :
+                                                     :        PORV =      12433656  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    4337413         4823        4342236    :    5847446     :   30542384      582563320     613105704   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    5043745          0          5043745    :    5041362     :       0         710260157     710260157   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 14           :
+                                                     :        PAV  =           272  BARSA             :
+                                                     :        PORV =      25328539  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      37             0             37      :    24506338    :       0            5154          5154     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       0             0             0       :    24555567    :       0             0             0       :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 15           :
+                                                     :        PAV  =           283  BARSA             :
+                                                     :        PORV =      89597072  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :     48577           43          48620     :    86528661    :    211567        7358847       7570414    :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :     36869           0           36869     :    86742407    :       0          5191921       5191921    :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 16           :
+                                                     :        PAV  =           273  BARSA             :
+                                                     :        PORV =      36879049  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    3961605          0          3961605    :    30084491    :       0         557868230     557868230   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    4271633          0          4271633    :    29794439    :       0         601531305     601531305   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 17           :
+                                                     :        PAV  =           282  BARSA             :
+                                                     :        PORV =       5687619  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    339548           0           339548    :    5025990     :       0          47815777      47815777   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    358721           0           358721    :    5011669     :       0          50515111      50515111   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 18           :
+                                                     :        PAV  =           283  BARSA             :
+                                                     :        PORV =       3145457  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    745192          6199         751390    :    1685514     :   49214337      133823177     183037514   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    703652          7945         711597    :    1723811     :   51388595      137866556     189255152   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 19           :
+                                                     :        PAV  =           254  BARSA             :
+                                                     :        PORV =       2355763  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    971586          1641         973227    :     872267     :   10078625      132758542     142837167   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    1201634          0          1201634    :     614786     :       0         169214078     169214078   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 20           :
+                                                     :        PAV  =           261  BARSA             :
+                                                     :        PORV =      18527269  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    5798812         714         5799525    :    9752141     :    4229788      813655054     817884842   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    7068011          0          7068011    :    8136152     :       0         995317254     995317254   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 21           :
+                                                     :        PAV  =           281  BARSA             :
+                                                     :        PORV =      28314973  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       0             0             0       :    27352080    :       0             0             0       :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       0             0             0       :    27437699    :       0             0             0       :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ===================================
+                                                     :  RESERVOIR VOLUMES      RM3     :
+ :---------:---------------:---------------:---------------:---------------:---------------:
+ : REGION  :  TOTAL PORE   :  PORE VOLUME  :  PORE VOLUME  :  PORE VOLUME  :  PORE VOLUME  :
+ :         :    VOLUME     :  CONTAINING   :  CONTAINING   :  CONTAINING   :  CONTAINING   :
+ :         :               :      OIL      :     WATER     :      GAS      : HYDRO-CARBON  :
+ :---------:---------------:---------------:---------------:---------------:---------------:
+ :FIELD    :      543910686:       58016519:      479467438:        6426729:       64443248:
+ :1        :       92154532:        2789846:       89162833:         201854:        2991700:
+ :2        :       23817841:        9410155:       14224943:         182744:        9592899:
+ :3        :       16270750:        2739659:       13435044:          96047:        2835706:
+ :4        :        7722267:         397412:        4380653:        2944201:        3341614:
+ :5        :        2276181:        1477976:         769763:          28442:        1506418:
+ :6        :       16693896:        9299652:        6943413:         450830:        9750483:
+ :7        :       31750093:           2695:       31747399:              0:           2695:
+ :8        :       99328882:         666858:       98580460:          81565:         748423:
+ :9        :        8460706:        4547872:        3912834:              0:        4547872:
+ :10       :       14244124:        1455206:       12788919:              0:        1455206:
+ :11       :        7263412:         626750:        4774449:        1862212:        2488962:
+ :12       :        1632707:        1130164:         371648:         130895:        1261059:
+ :13       :       12424468:        6216638:        6052809:         155020:        6371659:
+ :14       :       25352489:             53:       25352437:              0:             53:
+ :15       :       89628382:          71536:       89555876:            969:          72506:
+ :16       :       36870959:        5721430:       31149530:              0:        5721430:
+ :17       :        5690399:         489233:        5201166:              0:         489233:
+ :18       :        3146295:        1181257:        1744470:         220569:        1401825:
+ :19       :        2352550:        1398195:         903851:          50505:        1448700:
+ :20       :       18513983:        8393932:       10099175:          20876:        8414808:
+ :21       :       28315768:              0:       28315768:              0:              0:
+ ===========================================================================================
+
+
+Report step 50/82 at day 546/912, date = 01-Jul-2019
+
+Starting time step 0, stepsize 3 days, at day 546/572, date = 01-Jul-2019
+Restart file written for report step 50/82, date = 01-Jul-2019 00:00:00
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+Starting time step 1, stepsize 9 days, at day 549/572, date = 04-Jul-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  3 (0.3sec)
+
+Starting time step 2, stepsize 14 days, at day 558/572, date = 13-Jul-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  4 (0.3sec)
+
+
+Report step 51/82 at day 572/912, date = 27-Jul-2019
+
+Starting time step 0, stepsize 5 days, at day 572/577, date = 27-Jul-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step 52/82 at day 577/912, date = 01-Aug-2019
+
+Starting time step 0, stepsize 15 days, at day 577/592, date = 01-Aug-2019
+ Newton its= 5, linearizations= 6 (0.3sec), linear its=  6 (0.5sec)
+
+
+Report step 53/82 at day 592/912, date = 16-Aug-2019
+
+Starting time step 0, stepsize 8 days, at day 592/600, date = 16-Aug-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  2 (0.3sec)
+
+
+Report step 54/82 at day 600/912, date = 24-Aug-2019
+
+Starting time step 0, stepsize 8 days, at day 600/608, date = 24-Aug-2019
+ Newton its= 4, linearizations= 5 (0.3sec), linear its=  2 (0.4sec)
+
+
+Report step 55/82 at day 608/912, date = 01-Sep-2019
+
+Starting time step 0, stepsize 5 days, at day 608/613, date = 01-Sep-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  1 (0.2sec)
+
+
+Report step 56/82 at day 613/912, date = 06-Sep-2019
+
+Starting time step 0, stepsize 15 days, at day 613/638, date = 06-Sep-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  3 (0.4sec)
+
+Starting time step 1, stepsize 10 days, at day 628/638, date = 21-Sep-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  5 (0.3sec)
+
+
+Report step 57/82 at day 638/912, date = 01-Oct-2019
+
+Starting time step 0, stepsize 18 days, at day 638/656, date = 01-Oct-2019
+ Newton its= 4, linearizations= 5 (0.3sec), linear its=  4 (0.4sec)
+
+
+Report step 58/82 at day 656/912, date = 19-Oct-2019
+
+Starting time step 0, stepsize 13 days, at day 656/669, date = 19-Oct-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step 59/82 at day 669/912, date = 01-Nov-2019
+
+Starting time step 0, stepsize 1 days, at day 669/670, date = 01-Nov-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step 60/82 at day 670/912, date = 02-Nov-2019
+
+Starting time step 0, stepsize 3 days, at day 670/676, date = 02-Nov-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+Starting time step 1, stepsize 3 days, at day 673/676, date = 05-Nov-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step 61/82 at day 676/912, date = 08-Nov-2019
+
+Starting time step 0, stepsize 8 days, at day 676/684, date = 08-Nov-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  4 (0.3sec)
+
+
+Report step 62/82 at day 684/912, date = 16-Nov-2019
+
+Starting time step 0, stepsize 13 days, at day 684/697, date = 16-Nov-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  5 (0.3sec)
+
+
+Report step 63/82 at day 697/912, date = 29-Nov-2019
+
+Starting time step 0, stepsize 2 days, at day 697/699, date = 29-Nov-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step 64/82 at day 699/912, date = 01-Dec-2019
+
+Starting time step 0, stepsize 6 days, at day 699/730, date = 01-Dec-2019
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+Starting time step 1, stepsize 12.5 days, at day 705/730, date = 07-Dec-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  3 (0.3sec)
+
+Starting time step 2, stepsize 12.5 days, at day 717.5/730, date = 19-Dec-2019
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  3 (0.4sec)
+
+
+Report step 65/82 at day 730/912, date = 01-Jan-2020
+
+Starting time step 0, stepsize 10 days, at day 730/740, date = 01-Jan-2020
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step 66/82 at day 740/912, date = 11-Jan-2020
+
+Starting time step 0, stepsize 20 days, at day 740/760, date = 11-Jan-2020
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  4 (0.3sec)
+
+
+Report step 67/82 at day 760/912, date = 31-Jan-2020
+
+Starting time step 0, stepsize 1 days, at day 760/761, date = 31-Jan-2020
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step 68/82 at day 761/912, date = 01-Feb-2020
+
+Starting time step 0, stepsize 3 days, at day 761/768, date = 01-Feb-2020
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+Starting time step 1, stepsize 4 days, at day 764/768, date = 04-Feb-2020
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  1 (0.2sec)
+
+
+Report step 69/82 at day 768/912, date = 08-Feb-2020
+
+Starting time step 0, stepsize 6.5 days, at day 768/781, date = 08-Feb-2020
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  4 (0.2sec)
+
+Starting time step 1, stepsize 6.5 days, at day 774.5/781, date = 14-Feb-2020
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step 70/82 at day 781/912, date = 21-Feb-2020
+
+Starting time step 0, stepsize 9 days, at day 781/790, date = 21-Feb-2020
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step 71/82 at day 790/912, date = 01-Mar-2020
+
+Starting time step 0, stepsize 15.5 days, at day 790/821, date = 01-Mar-2020
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+Starting time step 1, stepsize 15.5 days, at day 805.5/821, date = 16-Mar-2020
+ Newton its= 4, linearizations= 5 (0.3sec), linear its=  4 (0.4sec)
+
+
+Report step 72/82 at day 821/912, date = 01-Apr-2020
+
+Starting time step 0, stepsize 3 days, at day 821/824, date = 01-Apr-2020
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step 73/82 at day 824/912, date = 04-Apr-2020
+
+Starting time step 0, stepsize 9 days, at day 824/844, date = 04-Apr-2020
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  3 (0.4sec)
+
+Starting time step 1, stepsize 11 days, at day 833/844, date = 13-Apr-2020
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  1 (0.3sec)
+
+
+Report step 74/82 at day 844/912, date = 24-Apr-2020
+
+Starting time step 0, stepsize 7 days, at day 844/851, date = 24-Apr-2020
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  1 (0.3sec)
+
+
+Report step 75/82 at day 851/912, date = 01-May-2020
+
+Starting time step 0, stepsize 1 days, at day 851/852, date = 01-May-2020
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  1 (0.3sec)
+
+
+Report step 76/82 at day 852/912, date = 02-May-2020
+
+Starting time step 0, stepsize 3 days, at day 852/855, date = 02-May-2020
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  3 (0.3sec)
+
+
+Report step 77/82 at day 855/912, date = 05-May-2020
+
+Starting time step 0, stepsize 5 days, at day 855/865, date = 05-May-2020
+ Newton its= 5, linearizations= 6 (0.3sec), linear its=  8 (0.6sec)
+
+Starting time step 1, stepsize 5 days, at day 860/865, date = 10-May-2020
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  3 (0.2sec)
+
+
+Report step 78/82 at day 865/912, date = 15-May-2020
+
+Starting time step 0, stepsize 8.5 days, at day 865/882, date = 15-May-2020
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  3 (0.3sec)
+
+Starting time step 1, stepsize 8.5 days, at day 873.5/882, date = 23-May-2020
+ Newton its= 3, linearizations= 4 (0.2sec), linear its=  4 (0.3sec)
+
+
+Report step 79/82 at day 882/912, date = 01-Jun-2020
+
+Starting time step 0, stepsize 26 days, at day 882/908, date = 01-Jun-2020
+ Newton its= 7, linearizations= 8 (0.4sec), linear its=  4 (0.7sec)
+
+
+Report step 80/82 at day 908/912, date = 27-Jun-2020
+
+Starting time step 0, stepsize 3 days, at day 908/911, date = 27-Jun-2020
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  2 (0.2sec)
+
+
+Report step 81/82 at day 911/912, date = 30-Jun-2020
+
+Starting time step 0, stepsize 1 days, at day 911/912, date = 30-Jun-2020
+
+Warning: Keyword 'FIPRESV' is unhandled for output to restart file.
+ Newton its= 2, linearizations= 3 (0.2sec), linear its=  1 (0.2sec)
+
+                              **************************************************************************
+  BALANCE  AT       912  DAYS *Drogon synthetic reservoir model                                          *
+  REPORT   82    01 Jul 2020  *                                             Flow  version 2025.10-pre  *
+                              **************************************************************************
+
+
+                                                     ==================================================
+                                                     :                  FIELD TOTALS                  :
+                                                     :        PAV  =           258  BARSA             :
+                                                     :        PORV =     543870734  RM3               :
+                                                     : Pressure is weighted by hydrocarbon pore volume:
+                                                     : Pore volumes are taken at reference conditions :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :   37029721        185964       37215685   :   467758076    :  1412441160     5032081967    6444523127  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :   45456650        184918       45641568   :   458478364    :  1201555717     6473854099    7675409816  :
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  1           :
+                                                     :        PAV  =           279  BARSA             :
+                                                     :        PORV =      92144333  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    1914185        12452        1926637    :    86092296    :   61824967      273743606     335568573   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    1971585          0          1971585    :    86497372    :       0         277638546     277638546   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  2           :
+                                                     :        PAV  =           255  BARSA             :
+                                                     :        PORV =      23847184  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    5786584         5328        5791912    :    14783041    :   32736343      797001148     829737491   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    7412666          0          7412666    :    12811296    :       0         1043851673    1043851673  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  3           :
+                                                     :        PAV  =           268  BARSA             :
+                                                     :        PORV =      16265885  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    1739933         3226        1743159    :    13210818    :   19981219      240454027     260435247   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    2462605          0          2462605    :    12337180    :       0         346784057     346784057   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  4           :
+                                                     :        PAV  =           283  BARSA             :
+                                                     :        PORV =       7720051  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    246890         80582         327472    :    4324921     :   637071405      45235962     682307366   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    232168         109290        341458    :    4147647     :   711438194      45488731     756926926   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  5           :
+                                                     :        PAV  =           253  BARSA             :
+                                                     :        PORV =       2279667  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    1028911         859         1029769    :     741843     :    5229207      140673051     145902258   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    1054576          0          1054576    :     743741     :       0         148505401     148505401   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  6           :
+                                                     :        PAV  =           214  BARSA             :
+                                                     :        PORV =      16715360  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    5927209        15652        5942861    :    7377640     :   138201444     671407660     809609103   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    7339772          0          7339772    :    5998550     :       0         1033586644    1033586644  :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  7           :
+                                                     :        PAV  =           268  BARSA             :
+                                                     :        PORV =      31732729  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :     1879            0            1879     :    30682650    :       0           264565        264565    :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       0             0             0       :    30749971    :       0             0             0       :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  8           :
+                                                     :        PAV  =           281  BARSA             :
+                                                     :        PORV =      99297143  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    466223          3689         469913    :    95251445    :   19691420       67159554      86850974   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    442638           0           442638    :    95552708    :       0          62332262      62332262   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION  9           :
+                                                     :        PAV  =           279  BARSA             :
+                                                     :        PORV =       8461267  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    2822934          0          2822934    :    4242392     :       0         397526306     397526306   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    3468315          0          3468315    :    3383744     :       0         488408096     488408096   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 10           :
+                                                     :        PAV  =           283  BARSA             :
+                                                     :        PORV =      14236567  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    950410           0           950410    :    12444168    :       0         133835465     133835465   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    1118839          0          1118839    :    12237246    :       0         157554944     157554944   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 11           :
+                                                     :        PAV  =           283  BARSA             :
+                                                     :        PORV =       7261494  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    396112         50726         446838    :    4671840     :   401398875      72174368     473573242   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    382426         67683         450109    :    4603488     :   438728927      74928792     513657719   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 12           :
+                                                     :        PAV  =           201  BARSA             :
+                                                     :        PORV =       1639655  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    828671          2347         831017    :     358878     :   21017336       87888626     108905962   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    886796           0           886796    :     357529     :       0         124878569     124878569   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 13           :
+                                                     :        PAV  =           252  BARSA             :
+                                                     :        PORV =      12433656  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    3906641         4888        3911529    :    6441841     :   30708096      526210479     556918575   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    5043745          0          5043745    :    5041362     :       0         710260157     710260157   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 14           :
+                                                     :        PAV  =           275  BARSA             :
+                                                     :        PORV =      25328539  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :      37             0             37      :    24509610    :       0            5154          5154     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       0             0             0       :    24555567    :       0             0             0       :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 15           :
+                                                     :        PAV  =           285  BARSA             :
+                                                     :        PORV =      89597072  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :     48456           37          48493     :    86557128    :    177649        7363482       7541131    :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :     36869           0           36869     :    86742407    :       0          5191921       5191921    :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 16           :
+                                                     :        PAV  =           276  BARSA             :
+                                                     :        PORV =      36879049  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    3764535          0          3764535    :    30375113    :       0         530117087     530117087   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    4271633          0          4271633    :    29794439    :       0         601531305     601531305   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 17           :
+                                                     :        PAV  =           285  BARSA             :
+                                                     :        PORV =       5687619  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    333909           0           333909    :    5035200     :       0          47021753      47021753   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    358721           0           358721    :    5011669     :       0          50515111      50515111   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 18           :
+                                                     :        PAV  =           284  BARSA             :
+                                                     :        PORV =       3145457  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    766072          4006         770079    :    1732912     :   31351951      137283079     168635030   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    703652          7945         711597    :    1723811     :   51388595      137866556     189255152   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 19           :
+                                                     :        PAV  =           257  BARSA             :
+                                                     :        PORV =       2355763  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    890688          1857         892545    :     977328     :   11202603      123017059     134219662   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    1201634          0          1201634    :     614786     :       0         169214078     169214078   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 20           :
+                                                     :        PAV  =           263  BARSA             :
+                                                     :        PORV =      18527269  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :    5209441         316         5209757    :    10586947    :    1848646      733699538     735548183   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :    7068011          0          7068011    :    8136152     :       0         995317254     995317254   :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ==================================================
+                                                     :              FIPNUM REPORT REGION 21           :
+                                                     :        PAV  =           283  BARSA             :
+                                                     :        PORV =      28314973  RM3               :
+                           :--------------- OIL  SM3 ------------------:-- WAT    SM3 --:--------------  GAS     SM3 ---------------:
+                           :    LIQUID         VAPOUR        TOTAL     :     TOTAL      :     FREE        DISSOLVED       TOTAL     :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :CURRENTLY IN PLACE       :       0             0             0       :    27360064    :       0             0             0       :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ :ORIGINALLY IN PLACE      :       0             0             0       :    27437699    :       0             0             0       :
+ :-------------------------:-------------------------------------------:----------------:-------------------------------------------:
+ ====================================================================================================================================
+
+
+
+                                                     ===================================
+                                                     :  RESERVOIR VOLUMES      RM3     :
+ :---------:---------------:---------------:---------------:---------------:---------------:
+ : REGION  :  TOTAL PORE   :  PORE VOLUME  :  PORE VOLUME  :  PORE VOLUME  :  PORE VOLUME  :
+ :         :    VOLUME     :  CONTAINING   :  CONTAINING   :  CONTAINING   :  CONTAINING   :
+ :         :               :      OIL      :     WATER     :      GAS      : HYDRO-CARBON  :
+ :---------:---------------:---------------:---------------:---------------:---------------:
+ :FIELD    :      543966841:       53202666:      484123888:        6640287:       59842952:
+ :1        :       92167537:        2772732:       89110225:         284580:        3057312:
+ :2        :       23822044:        8344003:       15314216:         163826:        8507829:
+ :3        :       16271854:        2502340:       13670896:          98618:        2600958:
+ :4        :        7722687:         393961:        4475889:        2852836:        3246798:
+ :5        :        2276349:        1481452:         768810:          26087:        1507539:
+ :6        :       16676634:        8197371:        7641745:         837518:        9034889:
+ :7        :       31752445:           2717:       31749728:              0:           2717:
+ :8        :       99342615:         676420:       98575705:          90489:         766910:
+ :9        :        8462232:        4071203:        4391029:              0:        4071203:
+ :10       :       14245501:        1369078:       12876423:              0:        1369078:
+ :11       :        7263892:         630993:        4835091:        1797808:        2428801:
+ :12       :        1632426:        1132196:         372766:         127465:        1259661:
+ :13       :       12425650:        5602014:        6668281:         155355:        5757369:
+ :14       :       25354429:             53:       25354376:              0:             53:
+ :15       :       89645089:          71384:       89572896:            809:          72194:
+ :16       :       36878037:        5432084:       31445953:              0:        5432084:
+ :17       :        5691043:         480768:        5210275:              0:         480768:
+ :18       :        3146548:        1213020:        1793418:         140110:        1353130:
+ :19       :        2352952:        1284633:        1012607:          55712:        1340345:
+ :20       :       18516372:        7544241:       10963056:           9074:        7553316:
+ :21       :       28320504:              0:       28320504:              0:              0:
+ ===========================================================================================
+
+Restart file written for report step 82/82, date = 01-Jul-2020 00:00:00
+
+
+================    End of simulation     ===============
+
+Number of MPI processes:         1
+Threads per MPI process:         1
+Setup time:                      1.40 s
+  Deck input:                    0.57 s
+Number of timesteps:           116
+Simulation time:               106.58 s
+  Assembly time:                24.64 s (Wasted: 0.0 s; 0.0%)
+    Well assembly:               0.49 s (Wasted: 0.0 s; 0.0%)
+  Linear solve time:            42.16 s (Wasted: 0.0 s; 0.0%)
+    Linear setup:               20.05 s (Wasted: 0.0 s; 0.0%)
+  Props/update time:            17.74 s (Wasted: 0.0 s; 0.0%)
+  Pre/post step:                21.07 s (Wasted: 0.0 s; 0.0%)
+  Output write time:             0.38 s
+Overall Linearizations:        483      (Wasted:     0; 0.0%)
+Overall Newton Iterations:     367      (Wasted:     0; 0.0%)
+Overall Linear Iterations:     481      (Wasted:     0; 0.0%)
+
+
+
+Error summary:
+Warnings          253
+Info              867
+Errors            0
+Bugs              0
+Debug             0
+Problems          0
+


### PR DESCRIPTION
Added a warning if the volume report extracted is not from the initial date.
Also removed unused suffix in result file folder.

closes #710 
closes #796

