### PR TITLE
Fix showing and saving plot in check_swatinit

### DIFF
--- a/src/subscript/check_swatinit/check_swatinit.py
+++ b/src/subscript/check_swatinit/check_swatinit.py
@@ -74,21 +74,21 @@ def main() -> None:
 
     if args.volplot or args.volplotfile:
         plotter.wvol_waterfall(qc_vols)
-    if args.volplot:
-        pyplot.show()
     if args.volplotfile:
         print(f"Dumping volume plot to {args.volplotfile}")
         pyplot.savefig(args.volplotfile)
+    if args.volplot:
+        pyplot.show()
 
     if (args.plotfile or args.plot) and args.eqlnum not in qc_frame["EQLNUM"].values:
         sys.exit(f"Error: EQLNUM {args.eqlnum} does not exist in grid. No plotting.")
     if args.plot or args.plotfile:
         plotter.plot_qc_panels(qc_frame[qc_frame["EQLNUM"] == args.eqlnum])
-    if args.plot:
-        pyplot.show()
     if args.plotfile:
         print(f"Dumping plot to {args.plotfile}")
         pyplot.savefig(args.plotfile)
+    if args.plot:
+        pyplot.show()
 
 
 def check_applicability(eclfiles: res2df.ResdataFiles) -> None:


### PR DESCRIPTION
Resolves #795 

From https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.show.html:
```
Notes

Saving figures to file and showing a window at the same time

If you want an image file as well as a user interface window, use [pyplot.savefig](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html#matplotlib.pyplot.savefig) 
before [pyplot.show](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.show.html#matplotlib.pyplot.show). 
At the end of (a blocking) show() the figure is closed and thus unregistered from pyplot. 
Calling [pyplot.savefig](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html#matplotlib.pyplot.savefig) afterwards would save a new and thus empty figure. 
This limitation of command order does not apply if the show is non-blocking or if you keep a reference to the figure and use [Figure.savefig](https://matplotlib.org/stable/api/_as_gen/matplotlib.figure.Figure.savefig.html#matplotlib.figure.Figure.savefig).
```