### PR TITLE
Disable ruff rule RUF069

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ ignore = [
     "PLR0904", # too-many-public-methods
     "PLR1702", # too-many-nested-blocks
     "RUF067",  # non empty init module
+    "RUF069",  # unreliable-floating-point-equality
     "PLC1901",  # compare-to-empty-string
 ]
 


### PR DESCRIPTION
See https://docs.astral.sh/ruff/rules/float-equality-comparison/

Might be worth enabling it later on, but seems to be quite prone to flagging "too much", cannot compare any input to 0.0 for instance.