### PR TITLE
 Disable ruff rule PLW0717

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,7 @@ ignore = [
     "RUF067",  # non empty init module
     "RUF069",  # unreliable-floating-point-equality
     "PLC1901",  # compare-to-empty-string
+    "PLW0717", # too-many-statements-in-try-clause ()
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]


### PR DESCRIPTION
 Disable ruff rule PLW0717 - too-many-statements-in-try-clause ()

https://docs.astral.sh/ruff/rules/too-many-statements-in-try-clause/