### PR TITLE
feat(merge_unrst_files): add --priority flag for overlapping report steps

### DIFF
--- a/src/subscript/hook_implementations/forward_model_steps.py
+++ b/src/subscript/hook_implementations/forward_model_steps.py
@@ -581,11 +581,26 @@ class MergeUnrstFiles(ForwardModelStepPlugin):
                 "<UNRST2>",
                 "--output",
                 "<OUTPUT>",
+                "--priority",
+                "<PRIORITY>",
             ],
             default_mapping={
                 "<OUTPUT>": "MERGED.UNRST",
+                "<PRIORITY>": "hist",
             },
         )
+
+    def validate_pre_experiment(self, fm_step_json: ForwardModelStepJSON) -> None:
+        errors = []
+
+        priority = self.private_args.get("<PRIORITY>")
+        if priority is not None and priority not in {"hist", "pred"}:
+            errors.append(f"<PRIORITY> must be 'hist' or 'pred', got '{priority}'.")
+
+        if errors:
+            raise ForwardModelStepValidationError(
+                "Validation failed for MERGE_UNRST_FILES:\n" + "\n".join(errors)
+            )
 
     @staticmethod
     def documentation() -> ForwardModelStepDocumentation | None:
@@ -598,6 +613,8 @@ class MergeUnrstFiles(ForwardModelStepPlugin):
   DEFINE <RESTART_DIR>      iter-3
   FORWARD_MODEL MERGE_UNRST_FILES(<UNRST1>=..<RESTART_DIR>/<ECLBASE>.UNRST, \
       <UNRST2>=<ECLBASE>.UNRST, <OUTPUT>=eclipse/model/ECLIPSE_MERGED.UNRST)
+  FORWARD_MODEL MERGE_UNRST_FILES(<UNRST1>=..<RESTART_DIR>/<ECLBASE>.UNRST, \
+      <UNRST2>=<ECLBASE>.UNRST, <OUTPUT>=MERGED.UNRST, <PRIORITY>=pred)
 
 """,
         )

--- a/src/subscript/merge_unrst_files/merge_unrst_files.py
+++ b/src/subscript/merge_unrst_files/merge_unrst_files.py
@@ -1,10 +1,15 @@
 import argparse
 import logging
+from typing import Any
 
-import numpy as np
 import resfo
 
 from subscript import __version__, getLogger
+
+# Type aliases
+KWEntry = tuple[str, Any]
+Chunk = list[KWEntry]
+
 
 DESCRIPTION = """Read two ``UNRST`` files and export a merged version. This is useful in
 cases where history and prediction are run separately and one wants to calculate
@@ -38,6 +43,14 @@ def get_parser() -> argparse.ArgumentParser:
         default="MERGED.UNRST",
     )
     parser.add_argument(
+        "--priority",
+        type=str,
+        choices=["hist", "pred"],
+        default="hist",
+        help="Which file to keep on overlapping report steps (default: hist)",
+    )
+
+    parser.add_argument(
         "-v",
         "--version",
         action="version",
@@ -46,29 +59,78 @@ def get_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _check_report_number(
-    args: argparse.Namespace,
-    max_report_number_hist: int,
-    current_report_number: int,
-) -> None:
-    """Check that pred file report numbers are larger than in hist file.
+def _get_overlap_interval(
+    hist_chunks: list[Chunk],
+    pred_chunks: list[Chunk],
+) -> tuple[int, int] | None:
+    """Determine the overlapping interval between hist and pred.
+
+    The overlap is defined as:
+        [max(min_hist, min_pred), min(max_hist, max_pred)]
+
+    Returns:
+        tuple: (overlap_start, overlap_end) or None if no overlap.
+    """
+    hist_seqnums: list[int] = [
+        s for c in hist_chunks if (s := _get_seqnum(c)) is not None
+    ]
+    pred_seqnums: list[int] = [
+        s for c in pred_chunks if (s := _get_seqnum(c)) is not None
+    ]
+
+    if not hist_seqnums or not pred_seqnums:
+        return None
+
+    logger.info(f"Hist report steps: {hist_seqnums}")
+    logger.info(f"Pred report steps: {pred_seqnums}")
+
+    overlap_start = max(hist_seqnums[0], pred_seqnums[0])
+    overlap_end = min(hist_seqnums[-1], pred_seqnums[-1])
+
+    if overlap_start <= overlap_end:
+        return (overlap_start, overlap_end)
+    return None
+
+
+def _is_in_interval(seqnum: int | None, interval: tuple[int, int] | None) -> bool:
+    """Check if a seqnum falls within the overlap interval."""
+    if interval is None or seqnum is None:
+        return False
+    return interval[0] <= seqnum <= interval[1]
+
+
+def _split_by_seqnum(data: list[KWEntry]) -> list[Chunk]:
+    """Split UNRST keyword list into chunks, one per report step.
+
+    Each chunk starts with a SEQNUM keyword and contains all keywords
+    until the next SEQNUM (or end of data).
 
     Args:
-        args (argparse.Namespace): The Namespace object with the argument list.
-        max_report_number_hist (int): The largest report number in hist file.
-        current_report_number (int): The current restart report number in pred file.
-    """
+        data: List of (keyword, value) tuples as returned by
+            resfo.read().
 
-    if current_report_number <= max_report_number_hist:
-        logger.warning(
-            f"{args.UNRST2} file has a restart report number ({current_report_number})"
-            + f" which is smaller than largest report number in {args.UNRST1}"
-            + f" ({max_report_number_hist})"
-        )
-        logger.warning(
-            "Check that you have entered arguments in correct order and/or"
-            + " that the unrst files are compatible."
-        )
+    Returns:
+        List of chunks, where each chunk is a list of
+        (keyword, value) tuples.
+    """
+    chunks: list[Chunk] = []
+    current_chunk: Chunk = []
+    for kw, val in data:
+        if kw == "SEQNUM  " and current_chunk:
+            chunks.append(current_chunk)
+            current_chunk = []
+        current_chunk.append((kw, val))
+    if current_chunk:
+        chunks.append(current_chunk)
+    return chunks
+
+
+def _get_seqnum(chunk: Chunk) -> int | None:
+    """Extract the SEQNUM value from a chunk."""
+    for kw, val in chunk:
+        if kw == "SEQNUM  ":
+            return int(val[0])
+    return None
 
 
 def main() -> None:
@@ -80,30 +142,40 @@ def main() -> None:
     unrst_hist = resfo.read(args.UNRST1)
     unrst_pred = resfo.read(args.UNRST2)
 
-    max_first_seqnum: int = 1
-    max_first_solver_step: int = 1
-    max_first_report_step: int = 1
+    hist_chunks = _split_by_seqnum(unrst_hist)
+    pred_chunks = _split_by_seqnum(unrst_pred)
 
-    for kw, val in unrst_hist:
-        if kw == "SEQNUM  ":  # restart report number
-            assert isinstance(val, np.ndarray)
-            max_first_seqnum = max(max_first_seqnum, val[0])
-        if kw == "INTEHEAD":
-            assert isinstance(val, np.ndarray)
-            max_first_solver_step = max(max_first_solver_step, val[67])
-            max_first_report_step = max(max_first_report_step, val[68])
+    overlap_interval = _get_overlap_interval(hist_chunks, pred_chunks)
 
-    for kw, val in unrst_pred:
-        if kw == "SEQNUM  ":
-            assert isinstance(val, np.ndarray)
-            _check_report_number(args, max_first_seqnum, val[0])
-            val[0] += max_first_seqnum
-        if kw == "INTEHEAD":
-            assert isinstance(val, np.ndarray)
-            val[67] += max_first_solver_step
-            val[68] += max_first_report_step
+    if overlap_interval:
+        logger.info(
+            "Overlapping report step interval detected: "
+            f"SEQNUM {overlap_interval[0]} to {overlap_interval[1]}"
+        )
+        logger.info(f"Keeping {args.priority} data in overlapping interval")
+    else:
+        logger.info("No overlapping report steps detected.")
 
-    resfo.write(args.output, unrst_hist + unrst_pred)
+    if args.priority == "hist":
+        filtered_hist = hist_chunks
+        filtered_pred = [
+            c
+            for c in pred_chunks
+            if not _is_in_interval(_get_seqnum(c), overlap_interval)
+        ]
+    else:
+        filtered_hist = [
+            c
+            for c in hist_chunks
+            if not _is_in_interval(_get_seqnum(c), overlap_interval)
+        ]
+        filtered_pred = pred_chunks
+
+    merged = [item for chunk in filtered_hist for item in chunk] + [
+        item for chunk in filtered_pred for item in chunk
+    ]
+
+    resfo.write(args.output, merged)
     logger.info(f"Done. Merged file is written to {args.output}")
 
 

--- a/tests/test_merge_unrst_files.py
+++ b/tests/test_merge_unrst_files.py
@@ -1,6 +1,7 @@
 import subprocess
 from pathlib import Path
 
+import numpy as np
 import pytest
 import resfo
 
@@ -42,6 +43,8 @@ def test_main_with_output(tmp_path, mocker, monkeypatch):
             "merge_unrst_files",
             str(UNRST_HIST),
             str(UNRST_PRED),
+            "--priority",
+            "hist",
             "-o",
             "MY_MERGED.UNRST",
         ],
@@ -52,7 +55,7 @@ def test_main_with_output(tmp_path, mocker, monkeypatch):
 
 
 def get_restart_report_numbers(unrst_merged):
-    """Get restart report numbers from merged unrst file. It should be [0, 82, 206]"""
+    """Get restart report numbers from merged unrst file."""
     report_numbers = []
     for kw, val in unrst_merged:
         if kw == "SEQNUM  ":
@@ -71,26 +74,185 @@ def test_check_report_numbers(tmp_path, mocker, monkeypatch):
             "merge_unrst_files",
             str(UNRST_HIST),
             str(UNRST_PRED),
+            "--priority",
+            "hist",
             "-o",
             "MY_MERGED.UNRST",
         ],
     )
     merge_unrst_files.main()
 
-    expected_report_numbers = [0, 82, 206]
+    expected_report_numbers = [0, 82, 124]
     report_numbers = get_restart_report_numbers(resfo.read("MY_MERGED.UNRST"))
 
-    print(
-        f"expected restart report numbers: {expected_report_numbers}, "
-        + f"actual restart report_numbers: {report_numbers}"
-    )
     assert report_numbers == expected_report_numbers
 
 
+def test_split_by_seqnum():
+    """Test splitting into chunks."""
+
+    data = [
+        ("SEQNUM  ", np.array([1])),
+        ("PRESSURE", np.array([1.0])),
+        ("SEQNUM  ", np.array([2])),
+        ("PRESSURE", np.array([2.0])),
+    ]
+
+    chunks = merge_unrst_files._split_by_seqnum(data)
+    assert len(chunks) == 2
+    assert merge_unrst_files._get_seqnum(chunks[0]) == 1
+    assert merge_unrst_files._get_seqnum(chunks[1]) == 2
+
+
+def test_is_in_interval():
+    """Test interval membership check."""
+    assert merge_unrst_files._is_in_interval(5, (3, 7)) is True
+    assert merge_unrst_files._is_in_interval(3, (3, 7)) is True
+    assert merge_unrst_files._is_in_interval(7, (3, 7)) is True
+    assert merge_unrst_files._is_in_interval(2, (3, 7)) is False
+    assert merge_unrst_files._is_in_interval(8, (3, 7)) is False
+    assert merge_unrst_files._is_in_interval(None, (3, 7)) is False
+    assert merge_unrst_files._is_in_interval(5, None) is False
+
+
+def test_get_overlap_interval():
+    """Test overlap detection logic."""
+
+    hist_data = [
+        ("SEQNUM  ", np.array([1])),
+        ("PRESSURE", np.array([1.0])),
+        ("SEQNUM  ", np.array([2])),
+        ("PRESSURE", np.array([2.0])),
+        ("SEQNUM  ", np.array([3])),
+        ("PRESSURE", np.array([3.0])),
+    ]
+    pred_data = [
+        ("SEQNUM  ", np.array([2])),
+        ("PRESSURE", np.array([2.5])),
+        ("SEQNUM  ", np.array([3])),
+        ("PRESSURE", np.array([3.5])),
+        ("SEQNUM  ", np.array([4])),
+        ("PRESSURE", np.array([4.0])),
+    ]
+
+    hist_chunks = merge_unrst_files._split_by_seqnum(hist_data)
+    pred_chunks = merge_unrst_files._split_by_seqnum(pred_data)
+
+    interval = merge_unrst_files._get_overlap_interval(hist_chunks, pred_chunks)
+    assert interval == (2, 3)
+
+
+def test_get_overlap_interval_no_overlap():
+    """Test when there is no overlap."""
+
+    hist_data = [
+        ("SEQNUM  ", np.array([1])),
+        ("SEQNUM  ", np.array([2])),
+    ]
+    pred_data = [
+        ("SEQNUM  ", np.array([3])),
+        ("SEQNUM  ", np.array([4])),
+    ]
+
+    hist_chunks = merge_unrst_files._split_by_seqnum(hist_data)
+    pred_chunks = merge_unrst_files._split_by_seqnum(pred_data)
+
+    interval = merge_unrst_files._get_overlap_interval(hist_chunks, pred_chunks)
+    assert interval is None
+
+
+@pytest.fixture
+def overlapping_unrst_files(tmp_path):
+    """Create overlapping UNRST files for testing."""
+
+    hist_data = [
+        ("SEQNUM  ", np.array([1], dtype=np.int32)),
+        ("PRESSURE", np.array([100.0])),
+        ("SEQNUM  ", np.array([2], dtype=np.int32)),
+        ("PRESSURE", np.array([200.0])),
+        ("SEQNUM  ", np.array([3], dtype=np.int32)),
+        ("PRESSURE", np.array([300.0])),
+    ]
+    pred_data = [
+        ("SEQNUM  ", np.array([2], dtype=np.int32)),
+        ("PRESSURE", np.array([250.0])),
+        ("SEQNUM  ", np.array([3], dtype=np.int32)),
+        ("PRESSURE", np.array([350.0])),
+        ("SEQNUM  ", np.array([4], dtype=np.int32)),
+        ("PRESSURE", np.array([400.0])),
+    ]
+
+    hist_path = tmp_path / "HIST.UNRST"
+    pred_path = tmp_path / "PRED.UNRST"
+    resfo.write(str(hist_path), hist_data)
+    resfo.write(str(pred_path), pred_data)
+    return hist_path, pred_path
+
+
+def test_priority_hist_with_overlap(overlapping_unrst_files, mocker, monkeypatch):
+    """Test --priority hist with overlapping data."""
+    hist_path, pred_path = overlapping_unrst_files
+    monkeypatch.chdir(hist_path.parent)
+
+    mocker.patch(
+        "sys.argv",
+        [
+            "merge_unrst_files",
+            str(hist_path),
+            str(pred_path),
+            "--priority",
+            "hist",
+            "-o",
+            "MERGED.UNRST",
+        ],
+    )
+    merge_unrst_files.main()
+
+    merged = resfo.read("MERGED.UNRST")
+
+    report_numbers = get_restart_report_numbers(merged)
+    # Hist keeps [1,2,3], pred stripped of [2,3], keeps [4]
+    assert report_numbers == [1, 2, 3, 4]
+
+    pressures = [val[0] for kw, val in merged if kw == "PRESSURE"]
+    # Hist values [100, 200, 300] kept, pred only contributes [400]
+    assert pressures == [100.0, 200.0, 300.0, 400.0]
+
+
+def test_priority_pred_with_overlap(overlapping_unrst_files, mocker, monkeypatch):
+    """Test --priority pred with overlapping data."""
+    hist_path, pred_path = overlapping_unrst_files
+    monkeypatch.chdir(hist_path.parent)
+
+    mocker.patch(
+        "sys.argv",
+        [
+            "merge_unrst_files",
+            str(hist_path),
+            str(pred_path),
+            "--priority",
+            "pred",
+            "-o",
+            "MERGED.UNRST",
+        ],
+    )
+    merge_unrst_files.main()
+
+    merged = resfo.read("MERGED.UNRST")
+
+    report_numbers = get_restart_report_numbers(merged)
+    # Hist stripped of [2,3], keeps [1]; pred keeps [2,3,4]
+    assert report_numbers == [1, 2, 3, 4]
+
+    pressures = [val[0] for kw, val in merged if kw == "PRESSURE"]
+    # Hist keeps [100], pred values [250, 350, 400] kept
+    assert pressures == [100.0, 250.0, 350.0, 400.0]
+
+
 @pytest.mark.integration
-def test_ert_integration(tmpdir, monkeypatch):
+def test_ert_integration(tmp_path, monkeypatch):
     pytest.importorskip("ert")
-    monkeypatch.chdir(tmpdir)
+    monkeypatch.chdir(tmp_path)
     ert_config = "config.ert"
     Path(ert_config).write_text(
         f"""
@@ -102,5 +264,12 @@ def test_ert_integration(tmpdir, monkeypatch):
         encoding="utf-8",
     )
 
-    subprocess.run(["ert", "test_run", "--disable-monitor", ert_config], check=True)
+    result = subprocess.run(
+        ["ert", "test_run", "--disable-monitor", ert_config],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"ERT failed.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
     assert Path("MERGED.UNRST").exists()


### PR DESCRIPTION
Closes #859 

- Add priority argument to choose hist or pred data on overlap
- Replace sequential numbering logic with chunk-based merging
- Add overlap interval detection between hist and pred files
- Add forward model step validation for priority parameter
- Add comprehensive tests for new overlap handling logic